### PR TITLE
Add clang-format to CI, PR template, etc

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -45,7 +45,7 @@ BinPackParameters:                              false
 BreakBeforeBinaryOperators:                     NonAssignment
 BreakBeforeTernaryOperators:                    true
 BreakConstructorInitializers:                   BeforeColon
-# BreakInheritanceList:                         BeforeColon # Requires clang-format-7
+BreakInheritanceList:                         BeforeColon # Requires clang-format-7
 BreakStringLiterals:                            true
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 
@@ -86,10 +86,10 @@ SpacesInCStyleCastParentheses:        false
 SpacesInContainerLiterals:            false
 SpacesInParentheses:                  false
 SpacesInSquareBrackets:               false
-# SpaceBeforeCpp11BracedList:         true # Requires clang-format-7
-# SpaceBeforeCtorInitializerColon:    true # Requires clang-format-7
-# SpaceBeforeInheritanceColon:        true # Requires clang-format-7
-# SpaceBeforeRangeBasedForLoopColon:  true # Requires clang-format-7
+SpaceBeforeCpp11BracedList:         true # Requires clang-format-7
+SpaceBeforeCtorInitializerColon:    true # Requires clang-format-7
+SpaceBeforeInheritanceColon:        true # Requires clang-format-7
+SpaceBeforeRangeBasedForLoopColon:  true # Requires clang-format-7
 
 ## Comments
 AlignTrailingComments:        true

--- a/.clang-format
+++ b/.clang-format
@@ -7,8 +7,20 @@ IndentWidth:        2
 UseTab:             Never
 BreakBeforeBraces:  Custom
 BraceWrapping:
-  BeforeCatch: true
-  BeforeElse: true
+  AfterClass:             false
+  AfterControlStatement:  false
+  AfterEnum:              false
+  AfterFunction:          false
+  AfterNamespace:         false
+  AfterStruct:            false
+  AfterUnion:             false
+  AfterExternBlock:       false
+  BeforeCatch:            true
+  BeforeElse:             true
+  IndentBraces:           false
+  SplitEmptyFunction:     false
+  SplitEmptyRecord:       false
+  SplitEmptyNamespace:    false
 
 
 ## Single liners

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,3 +23,4 @@ While we look over every pull request, we maintain a focus on this project's cur
 
 - [ ] I have added tests.
 - [ ] I have added necessary documentation.
+- [ ] I have auto formatted using clang-format or yapf.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ notifications:
     on_failure: change #[always|never|change] # default: always
 
 env:
+  global:
+    - CLANG_FORMAT_CHECK="file"
+    - CLANG_FORMAT_VERSION="7"
   matrix:
     - ROS_DISTRO="melodic"   ROS_REPO="ros"
     - ROS_DISTRO="melodic"   ROS_REPO="ros-shadow-fixed"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,19 @@ Once the workspace has been setup for cross-compilation, you can native or cross
     $ catkin profile set <native|cross>
     $ catkin build
 
+## Code Style
+
+We largely follow the ROS coding guidelines, with a few noteable exceptions. To make development easy, we provide configuration files for standard linting and static analysis tools such as [clang-format](https://clang.llvm.org/docs/ClangFormat.html), [clang-tidy](https://clang.llvm.org/extra/clang-tidy) and [yapf](https://github.com/google/yapf).
+
+Install the linters:
+
+    $ sudo apt install clang-format-7 clang-tidy-7 yapf
+
+To run the linters:
+
+    $ find . -name "*.h" -o -name "*.cpp" | xargs clang-format-7 -i -style=file
+    $ yapf -ir .
+
 ## Contributing
 
 We facilitate a completely open source environment for all of our projects, and are always welcoming contributors.

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
@@ -147,7 +147,7 @@ public:
                         const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
   /// Enforce limits for all values before writing.
-  virtual void enforceLimits(ros::Duration& period){};
+  virtual void enforceLimits(ros::Duration& period) {};
 
   /// Get the short name of the class.
   inline std::string getName() const { return name_; }

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -207,7 +207,7 @@ bool FRCRobotHWReal::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh
       // TODO: Get associated TalonSRX by name
     };
 
-    pigeons_[pair.first] = boost::apply_visitor(Visitor{}, pair.second.interface);
+    pigeons_[pair.first] = boost::apply_visitor(Visitor(), pair.second.interface);
   }
 #endif
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
This is a step towards enforcing code style. The PR template will now ask that you have auto formatted your code, and CI will fail if code is non-conforming. Also added a bit more info about code style to the README. Currently, only the `clang-format` is checked in CI, since we don't have rules for `yapf` or `clang-tidy`.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have added tests.
- [x] I have added necessary documentation.
