### PR TITLE
Add clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,10 +7,10 @@ Checks:  '-*,
           modernize-*,
           performance-*,
           readability-*,
-          -modernize-raw-string-literal,
-          -cppcoreguidelines-pro-type-vararg,
           -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
           -cppcoreguidelines-pro-bounds-constant-array-index,
+          -cppcoreguidelines-pro-type-vararg,
+          -modernize-raw-string-literal,
           -readability-braces-around-statements,
           -readability-misleading-indentation'
 
@@ -19,16 +19,16 @@ Checks:  '-*,
 # cppcoreguidelines-pro-bounds-array-to-pointer-decay
 
 ## Handled by clang-format:
-# readability-braces-around-statements
 # readability-misleading-indentation
 
 ## Disabled:
-# modernize-raw-string-literal
 # cppcoreguidelines-pro-bounds-constant-array-index
+# modernize-raw-string-literal
+# readability-braces-around-statements
 
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
+AnalyzeTemporaryDtors: false # TODO: Figure out what this does
 FormatStyle: none
 CheckOptions:
   # Prefer assignment over brace initialization

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,71 @@
+---
+Checks:  '-*,
+          boost-*,
+          bugprone-*,
+          cppcoreguidelines-*,
+          misc-*,
+          modernize-*,
+          performance-*,
+          readability-*,
+          -modernize-raw-string-literal,
+          -cppcoreguidelines-pro-type-vararg,
+          -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+          -cppcoreguidelines-pro-bounds-constant-array-index,
+          -readability-braces-around-statements,
+          -readability-misleading-indentation'
+
+## Disabled to allow ROS logging:
+# cppcoreguidelines-pro-type-vararg
+# cppcoreguidelines-pro-bounds-array-to-pointer-decay
+
+## Handled by clang-format:
+# readability-braces-around-statements
+# readability-misleading-indentation
+
+## Disabled:
+# modernize-raw-string-literal
+# cppcoreguidelines-pro-bounds-constant-array-index
+
+WarningsAsErrors: ''
+HeaderFilterRegex: ''
+AnalyzeTemporaryDtors: false
+FormatStyle: none
+CheckOptions:
+  # Prefer assignment over brace initialization
+  - key:    modernize-use-default-member-init.UseAssignment
+    value:  1
+
+  # Allow integer and pointer boolean conversions
+  - key:    readability-implicit-bool-conversion.AllowIntegerConditions
+    value:  1
+  - key:    readability-implicit-bool-conversion.AllowPointerConditions
+    value:  1
+
+  # Type names
+  - key:    readability-identifier-naming.ClassCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.EnumCase
+    value:  CamelCase
+  - key:    readability-identifier-naming.UnionCase
+    value:  CamelCase
+
+  # Method names
+  - key:    readability-identifier-naming.MethodCase
+    value:  camelBack
+
+  # Variable names
+  - key:    readability-identifier-naming.VariableCase
+    value:  lower_case
+  - key:    readability-identifier-naming.ClassMemberSuffix
+    value:  '_'
+
+  # Const static or global variables are UPPER_CASE
+  - key:    readability-identifier-naming.EnumConstantCase
+    value:  UPPER_CASE
+  - key:    readability-identifier-naming.StaticConstantCase
+    value:  UPPER_CASE
+  - key:    readability-identifier-naming.ClassConstantCase
+    value:  UPPER_CASE
+  - key:    readability-identifier-naming.GlobalVariableCase
+    value:  UPPER_CASE
+...

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
@@ -126,7 +126,7 @@ public:
    * For example, it could specify a CANTalon with builtin encoder feedback, a VictorSP with
    * an encoder on the specified port, etc
    */
-  void loadJoints(const ros::NodeHandle nh, const std::string& param_name);
+  void loadJoints(const ros::NodeHandle& nh, const std::string& param_name);
 
   /**
    * @brief Update all the Joint States of the robot

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -64,7 +64,7 @@ void FRCRobotHW::loadURDF(const ros::NodeHandle& nh, const std::string& param_na
   }
 }
 
-void FRCRobotHW::loadJoints(const ros::NodeHandle nh, const std::string& param_name) {
+void FRCRobotHW::loadJoints(const ros::NodeHandle& nh, const std::string& param_name) {
   using XmlValue = XmlRpc::XmlRpcValue;
   using namespace hardware_template;
 
@@ -89,6 +89,7 @@ void FRCRobotHW::loadJoints(const ros::NodeHandle nh, const std::string& param_n
   }
 
   // Parse each joint and store it in its respective map
+  // NOLINTNEXTLINE(modernize-loop-convert)
   for (uint i = 0; i < joint_param_list.size(); i++) {
     XmlValue cur_joint = joint_param_list[i];
     ROS_INFO_STREAM(cur_joint);
@@ -883,11 +884,11 @@ void FRCRobotHW::doSwitch(const std::list<hardware_interface::ControllerInfo>& s
   }
 }
 
-void FRCRobotHW::read(const ros::Time& time, const ros::Duration& period) {
+void FRCRobotHW::read(const ros::Time& /*time*/, const ros::Duration& /*period*/) {
   ROS_INFO_THROTTLE_NAMED(1, name_, "Reading Data - Overload me!");
 }
 
-void FRCRobotHW::write(const ros::Time& time, const ros::Duration& period) {
+void FRCRobotHW::write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {
   ROS_INFO_THROTTLE_NAMED(1, name_, "Writing Data - Overload me!");
 }
 

--- a/frc_robot_sim/include/frc_robot_sim/gazebo_hw_plugin.h
+++ b/frc_robot_sim/include/frc_robot_sim/gazebo_hw_plugin.h
@@ -45,7 +45,7 @@ public:
   void Reset() override;
 
   /// Update ros_control (read & write, maybe update) every simulation step
-  void WorldUpdate(const gazebo::common::UpdateInfo& info);
+  void worldUpdate(const gazebo::common::UpdateInfo& info);
 
 private:
   /// Namespace to spawn the robot in

--- a/frc_robot_sim/src/frc_robot_hw_sim.cpp
+++ b/frc_robot_sim/src/frc_robot_hw_sim.cpp
@@ -31,14 +31,14 @@ namespace frc_robot_sim {
 
 bool FRCRobotHWSim::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
   if (!FRCRobotHW::init(root_nh, robot_hw_nh))
-    return false;
+    return false;  // NOLINT(readability-simplify-boolean-expr)
 
   // TODO: Any other require initialization
 
   return true;
 }
 
-void FRCRobotHWSim::read(const ros::Time& time, const ros::Duration& period) {
+void FRCRobotHWSim::read(const ros::Time& /*time*/, const ros::Duration& /*period*/) {
 
   // Read all simple speed controllers
   for (const auto& pair : simple_speed_controller_templates_) {
@@ -88,7 +88,7 @@ void FRCRobotHWSim::read(const ros::Time& time, const ros::Duration& period) {
   // TODO: Support DigitalInput, AnalogInput, IMUs
 }
 
-void FRCRobotHWSim::write(const ros::Time& time, const ros::Duration& period) {
+void FRCRobotHWSim::write(const ros::Time& /*time*/, const ros::Duration& /*period*/) {
 
   // Command all simple speed controllers
   for (const auto& pair : simple_speed_controller_templates_) {

--- a/frc_robot_sim/src/gazebo_hw_plugin.cpp
+++ b/frc_robot_sim/src/gazebo_hw_plugin.cpp
@@ -72,7 +72,7 @@ void GazeboHWPlugin::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) 
 
   // Listen to the world update event. This event is broadcast every simulation step.
   update_connection_ = gazebo::event::Events::ConnectWorldUpdateBegin(
-      std::bind(&GazeboHWPlugin::WorldUpdate, this, std::placeholders::_1));
+      std::bind(&GazeboHWPlugin::worldUpdate, this, std::placeholders::_1));
 
   ROS_INFO_STREAM_NAMED(name_, "Loaded " << name_);
 }
@@ -83,7 +83,7 @@ void GazeboHWPlugin::Reset() {
   last_update_time_ = ros::Time();
 }
 
-void GazeboHWPlugin::WorldUpdate(const gazebo::common::UpdateInfo& info) {
+void GazeboHWPlugin::worldUpdate(const gazebo::common::UpdateInfo& info) {
   const ros::Time now(info.simTime.sec, info.simTime.nsec);
   const bool&     update_controllers = (now - last_update_time_) > control_period_;
 

--- a/run_clang_tidy.py
+++ b/run_clang_tidy.py
@@ -56,7 +56,9 @@ def check_package(pkg_name):
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(description='Wrapper for running clang-tidy on a catkin workspace')
+    parser = argparse.ArgumentParser(description='Wrapper for running clang-tidy on a catkin workspace.',
+                                     epilog='Note: In order for clang-tidy to understand which files to tidy, ' +
+                                     'the workspace must be built with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON.')
     parser.add_argument('-f', '--fix', help='Attempt to automatically fix issues', action='store_true')
     parser.add_argument('-j', '--jobs', help='Number of packages to tidy concurrently (default=4)', default=4, type=int)
     parser.add_argument('-q', '--quiet', help='Do not produce any stdout output', action='store_true')

--- a/run_clang_tidy.py
+++ b/run_clang_tidy.py
@@ -73,7 +73,7 @@ if __name__ == '__main__':
     cwd = os.path.dirname(os.path.realpath(__file__))
     ws = subprocess.check_output(['catkin', 'locate'], cwd=cwd).decode('utf-8').strip()
     build_dir = subprocess.check_output(
-        'catkin config | grep "Build Space:" | grep -o /.*"', cwd=cwd, shell=True).decode('utf-8').strip()
+        'catkin config | grep "Build Space:" | grep -o "/.*"', cwd=cwd, shell=True).decode('utf-8').strip()
 
     # Generate the list of packages to check
     package_list = []

--- a/run_clang_tidy.py
+++ b/run_clang_tidy.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+import argparse
+import json
+import subprocess
+import os
+
+from multiprocessing.pool import ThreadPool as Pool
+
+
+def check_package(pkg_name):
+    cur_dir = '/'.join([build_dir, pkg_name])
+    cur_file = '/'.join([build_dir, pkg_name, 'compile_commands.json'])
+    if not os.path.isfile(cur_file):
+        return False
+
+    with open(cur_file, 'r') as f:
+        parsed = json.load(f)
+        valid = []
+
+        for p in parsed:
+            if 'gtest' not in p['directory']:
+                valid.append(p)
+
+    with open(cur_file, 'w') as f:
+        json.dump(valid, f)
+
+    output_dir = '/'.join([ws, 'clang-tidy-fixes'])
+    if not os.path.isdir(output_dir):
+        os.mkdir(output_dir)
+    output_file = '/'.join([ws, 'clang-tidy-fixes', pkg_name + '_fixes'])
+    devnull = open(os.devnull, 'w')
+
+    if args.fix:
+        additional_args = ['-fix', '-format']
+    else:
+        additional_args = ['-export-fixes', output_file]
+
+    subprocess.call(['run-clang-tidy-7', '-j', '8', '-p', cur_dir] + additional_args, stdout=devnull, stderr=devnull)
+
+    if args.fix:
+        if not args.quiet:
+            print('Finished tidying ' + pkg_name)
+        return False
+    else:
+        found_changes = os.stat(output_file).st_size != 0
+        if not found_changes:
+            os.remove(output_file)
+            if not args.quiet:
+                print('Finished checking ' + pkg_name + ', no changes required')
+        else:
+            if not args.quiet:
+                print('Finished checking ' + pkg_name + ', changes required! See ' + output_file)
+            if args.verbose:
+                print(open(output_file).read())
+        return found_changes
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser(description='Wrapper for running clang-tidy on a catkin workspace')
+    parser.add_argument('-f', '--fix', help='Attempt to automatically fix issues', action='store_true')
+    parser.add_argument('-q', '--quiet', help='Do not produce any stdout output', action='store_true')
+    parser.add_argument('-v', '--verbose', help='Output generated changefiles to stdout', action='store_true')
+    args = parser.parse_args()
+
+    if args.verbose and args.quiet:
+        print('Illegal usage, cannot set both quiet and verbose')
+        exit(-1)
+
+    cwd = os.path.dirname(os.path.realpath(__file__))
+    ws = subprocess.check_output(['catkin', 'locate'], cwd=cwd).strip()
+    build_dir = '/'.join([ws, 'build_native'])
+
+    pool = Pool(4)
+    returns = pool.map(check_package, [pkg_name for pkg_name in os.listdir(build_dir)])
+
+    if True in returns:
+        if not args.quiet:
+            print 'Changes required'
+        exit(1)
+    else:
+        exit(0)

--- a/setup_catkin.bash
+++ b/setup_catkin.bash
@@ -23,10 +23,14 @@ catkin profile set cross
 catkin config --extend ~/frc2019/roborio/arm-frc2019-linux-gnueabi/opt/ros/melodic\
               --space-suffix _cross\
               --blacklist frc_robot_sim\
-              -DCMAKE_TOOLCHAIN_FILE="${WSPATH}/rostoolchain.cmake"
+              -DCMAKE_TOOLCHAIN_FILE="${WSPATH}/rostoolchain.cmake"\
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\
+              -DCMAKE_CXX_CLANG_TIDY=clang-tidy-7
 
 # Setup the native compile profile
 catkin profile add native
 catkin profile set native
 catkin config --extend /opt/ros/melodic\
               --space-suffix _native\
+              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON\
+              -DCMAKE_CXX_CLANG_TIDY=clang-tidy-7


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
Closes #37. Adds a `clang-tidy` config file, as well as a wrapper to easily use `clang-tidy` in a catkin workspace. Default behaviour is to generate a file for each package of the requested changes in `workspace/clang-tidy-fixes`. For example, `workspace/clang-tidy-fixes/package1_fixes`. If the `-f` option is specified, the tool will automatically attempt to fix the issues it encounters. This behaviour is not the default since although `clang-tidy` is great at finding and describing errors, it can often do a poor job of fixing issues itself.

~TODO: Still need to add ability to blacklist/whitelist packages, since currently all packages in the workspace will be tidied.~
Added in d85d37b. Syntax: `run_clang_tidy.py [packages...]`. If no packages are specified, all packages in the workspace are tidied. Is able to handle metapackages.

~TODO: Need to add `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` and maybe  `-DCMAKE_CXX_CLANG_TIDY=clang-tidy-7` to catkin config~
Added in b8144ad

Full help text:
```
usage: run_clang_tidy.py [-h] [-f] [-j JOBS] [-q] [-v]
                         [packages [packages ...]]

Wrapper for running clang-tidy on a catkin workspace.

positional arguments:
  packages              List of packages to tidy

optional arguments:
  -h, --help            show this help message and exit
  -f, --fix             Attempt to automatically fix issues
  -j JOBS, --jobs JOBS  Number of packages to tidy concurrently (default=4)
  -q, --quiet           Do not produce any stdout output
  -v, --verbose         Output generated changefiles to stdout

Note: In order for clang-tidy to understand which files to tidy, the workspace
must be built with -DCMAKE_EXPORT_COMPILE_COMMANDS=ON.
```


## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
