### PR TITLE
Driver Station/FMS Messages

### DIFF
--- a/frc_control/package.xml
+++ b/frc_control/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>frc_msgs</exec_depend>
   <exec_depend>frc_robot_hw</exec_depend>
   <exec_depend>frc_robot_sim</exec_depend>
   <exec_depend>analog_state_controller</exec_depend>

--- a/frc_msgs/CMakeLists.txt
+++ b/frc_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ add_message_files(
     JoyArray.msg
     JoyFeedback.msg
     MatchData.msg
+    MatchTime.msg
     RobotState.msg
 )
 

--- a/frc_msgs/CMakeLists.txt
+++ b/frc_msgs/CMakeLists.txt
@@ -8,7 +8,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
 )
 
-# Generate messages in the 'msg' folder
+# List messages for generation
 add_message_files(
   FILES
     CANStatus.msg
@@ -20,25 +20,11 @@ add_message_files(
     RobotState.msg
 )
 
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#     Service1.srv
-#     Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-# Generate added messages and services with any dependencies listed here
+# Generate messages with the specified dependencies
 generate_messages(
   DEPENDENCIES
-  std_msgs
-  sensor_msgs
+    std_msgs
+    sensor_msgs
 )
 
 # Declare a catkin package

--- a/frc_msgs/CMakeLists.txt
+++ b/frc_msgs/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(frc_msgs)
+
+# Load catkin and package dependencies
+find_package(catkin REQUIRED COMPONENTS
+  std_msgs
+  sensor_msgs
+  message_generation
+)
+
+# Generate messages in the 'msg' folder
+add_message_files(
+  FILES
+    CANStatus.msg
+    DriverStationMode.msg
+    JoyArray.msg
+    JoyFeedback.msg
+    MatchData.msg
+    RobotState.msg
+)
+
+## Generate services in the 'srv' folder
+# add_service_files(
+#   FILES
+#     Service1.srv
+#     Service2.srv
+# )
+
+## Generate actions in the 'action' folder
+# add_action_files(
+#   FILES
+#   Action1.action
+#   Action2.action
+# )
+
+# Generate added messages and services with any dependencies listed here
+generate_messages(
+  DEPENDENCIES
+  std_msgs
+  sensor_msgs
+)
+
+# Declare a catkin package
+catkin_package(
+  CATKIN_DEPENDS
+    std_msgs
+    sensor_msgs
+    message_runtime
+)

--- a/frc_msgs/msg/CANStatus.msg
+++ b/frc_msgs/msg/CANStatus.msg
@@ -1,0 +1,7 @@
+# Corresponds to frc::CANStatus in RobotController.h
+Header header
+float32 percent_bus_utilization
+int32 bus_off_count
+int32 tx_full_count
+int32 receive_error_count
+int32 transmit_error_count

--- a/frc_msgs/msg/DriverStationMode.msg
+++ b/frc_msgs/msg/DriverStationMode.msg
@@ -1,0 +1,10 @@
+uint8 MODE_ESTOP = 0
+uint8 MODE_DISABLED = 1
+uint8 MODE_OPERATOR = 2
+uint8 MODE_AUTONOMOUS = 3
+uint8 MODE_TEST = 4
+
+Header header
+uint8 mode
+bool is_ds_attached
+bool is_fms_attached

--- a/frc_msgs/msg/DriverStationMode.msg
+++ b/frc_msgs/msg/DriverStationMode.msg
@@ -1,3 +1,4 @@
+# Corresponds to frc::DriverStation
 uint8 MODE_ESTOP = 0
 uint8 MODE_DISABLED = 1
 uint8 MODE_OPERATOR = 2

--- a/frc_msgs/msg/JoyArray.msg
+++ b/frc_msgs/msg/JoyArray.msg
@@ -27,5 +27,5 @@ int8 HID_1ST_PERSON = 24
 # They do not count towards the axis limits
 Header header
 sensor_msgs/Joy[] sticks
-int8[] type
-string[] name
+int8[] types
+string[] names

--- a/frc_msgs/msg/JoyArray.msg
+++ b/frc_msgs/msg/JoyArray.msg
@@ -1,0 +1,31 @@
+# Corresponds to definitions in DriverStationTypes.h
+uint8 MAX_JOYSTICK_AXES = 12
+uint8 MAX_JOYSTICK_POVS = 12
+uint8 MAX_JOYSTICK_BUTTONS = 32
+uint8 MAX_JOYSTICKS = 6
+
+# Corresponds to frc::GenericHID::HIDType
+int8 HID_UNKNOWN = -1
+int8 HID_XINPUT_UNKNOWN = 0
+int8 HID_XINPUT_GAMEPAD = 1
+int8 HID_XINPUT_WHEEL = 2
+int8 HID_XINPUT_ARCADE_STICK = 3
+int8 HID_XINPUT_FLIGHT_STICK = 4
+int8 HID_XINPUT_DANCE_PAD = 5
+int8 HID_XINPUT_GUITAR = 6
+int8 HID_XINPUT_GUITAR2 = 7
+int8 HID_XINPUT_DRUM_KIT = 8
+int8 HID_XINPUT_GUITAR3 = 11
+int8 HID_XINPUT_ARCADE_PAD = 19
+int8 HID_JOYSTICK = 20
+int8 HIT_GAMEPAD = 21
+int8 HID_DRIVING = 22
+int8 HID_FLIGHT = 23
+int8 HID_1ST_PERSON = 24
+
+# Note: We will treat POVs as both buttons and axes
+# They do not count towards the axis limits
+Header header
+sensor_msgs/Joy[] sticks
+int8[] type
+string[] name

--- a/frc_msgs/msg/JoyFeedback.msg
+++ b/frc_msgs/msg/JoyFeedback.msg
@@ -1,0 +1,2 @@
+uint16[] left_rumble
+uint16[] right_rumble

--- a/frc_msgs/msg/JoyFeedback.msg
+++ b/frc_msgs/msg/JoyFeedback.msg
@@ -1,2 +1,7 @@
-uint16[] left_rumble
-uint16[] right_rumble
+# Corresponds to frc::GenericHID::SetOutputs() and ::SetRumble()
+uint8 MAX_JOYSTICKS = 6
+
+Header header
+uint16[] left_rumbles
+uint16[] right_rumbles
+uint32[] outputs

--- a/frc_msgs/msg/MatchData.msg
+++ b/frc_msgs/msg/MatchData.msg
@@ -1,0 +1,25 @@
+# Corresponds to frc::DriverStation::MatchType
+uint8 MATCH_TYPE_NONE = 0
+uint8 MATCH_TYPE_PRACTICE = 1
+uint8 MATCH_TYPE_QUALIFICATION = 2
+uint8 MATCH_TYPE_ELIMINATION = 3
+
+# Corresponds to frc::DriverStation::Alliance
+uint8 ALLIANCE_RED = 0
+uint8 ALLIANCE_BLUE = 1
+uint8 ALLIANCE_INVALID = 2
+
+# Corresponds to return of frc::DriverStation::GetLocation()
+uint8 LOCATION_INVALID = 0
+uint8 LOCATION_LEFT = 1
+uint8 LOCATION_CENTER = 2
+uint8 LOCATION_RIGHT = 3
+
+Header header
+string game_specific_message
+string event_name
+uint8 match_type
+uint8 match_number
+uint8 replay_number
+uint8 alliance
+uint8 location

--- a/frc_msgs/msg/MatchData.msg
+++ b/frc_msgs/msg/MatchData.msg
@@ -19,7 +19,7 @@ Header header
 string game_specific_message
 string event_name
 uint8 match_type
-uint8 match_number
-uint8 replay_number
+int32 match_number
+int32 replay_number
 uint8 alliance
 uint8 location

--- a/frc_msgs/msg/MatchTime.msg
+++ b/frc_msgs/msg/MatchTime.msg
@@ -1,0 +1,7 @@
+# Corresponds to return of frc::DriverStation::GetMatchTime()
+
+# This is is an approximate representation of the number of seconds remaining
+# in the current period (teleop or auto). It is not exact. Total match time
+# (ie teleop + auto) is not provided.
+Header header
+float32 remaining_time

--- a/frc_msgs/msg/MatchTime.msg
+++ b/frc_msgs/msg/MatchTime.msg
@@ -4,4 +4,4 @@
 # in the current period (teleop or auto). It is not exact. Total match time
 # (ie teleop + auto) is not provided.
 Header header
-float32 remaining_time
+float64 remaining_time

--- a/frc_msgs/msg/RobotState.msg
+++ b/frc_msgs/msg/RobotState.msg
@@ -1,0 +1,22 @@
+# Corresponds to frc::RobotController
+Header header
+#int32 fpga_version
+#int64 fpga_revision
+#uint64 fpga_time
+bool user_button
+bool sys_active
+bool browned_out
+float32 input_voltage
+float32 input_current
+float32 voltage_3v3
+float32 current_3v3
+bool enabled_3v3
+float32 voltage_5v
+float32 current_5v
+bool enabled_5v
+#int32 fault_count_5v
+float32 voltage_6v
+float32 current_6v
+bool enabled_6v
+#int32 fault_count_6v
+CANStatus can_status

--- a/frc_msgs/msg/RobotState.msg
+++ b/frc_msgs/msg/RobotState.msg
@@ -6,21 +6,21 @@ uint64 fpga_time
 bool user_button
 bool sys_active
 bool browned_out
-float32 input_voltage
-float32 input_current
-float32 voltage_3v3
-float32 current_3v3
+float64 input_voltage
+float64 input_current
+float64 voltage_3v3
+float64 current_3v3
 bool enabled_3v3
 int32 fault_count_3v3
-float32 voltage_5v
-float32 current_5v
+float64 voltage_5v
+float64 current_5v
 bool enabled_5v
 int32 fault_count_5v
-float32 voltage_6v
-float32 current_6v
+float64 voltage_6v
+float64 current_6v
 bool enabled_6v
 int32 fault_count_6v
 CANStatus can_status
 
 # Corresponds to frc::DriverStation::GetBatteryVoltage()
-float32 battery_voltage
+float64 battery_voltage

--- a/frc_msgs/msg/RobotState.msg
+++ b/frc_msgs/msg/RobotState.msg
@@ -1,8 +1,8 @@
 # Corresponds to frc::RobotController
 Header header
-#int32 fpga_version
-#int64 fpga_revision
-#uint64 fpga_time
+int32 fpga_version
+int64 fpga_revision
+uint64 fpga_time
 bool user_button
 bool sys_active
 bool browned_out
@@ -11,14 +11,15 @@ float32 input_current
 float32 voltage_3v3
 float32 current_3v3
 bool enabled_3v3
+int32 fault_count_3v3
 float32 voltage_5v
 float32 current_5v
 bool enabled_5v
-#int32 fault_count_5v
+int32 fault_count_5v
 float32 voltage_6v
 float32 current_6v
 bool enabled_6v
-#int32 fault_count_6v
+int32 fault_count_6v
 CANStatus can_status
 
 # Corresponds to frc::DriverStation::GetBatteryVoltage()

--- a/frc_msgs/msg/RobotState.msg
+++ b/frc_msgs/msg/RobotState.msg
@@ -20,3 +20,6 @@ float32 current_6v
 bool enabled_6v
 #int32 fault_count_6v
 CANStatus can_status
+
+# Corresponds to frc::DriverStation::GetBatteryVoltage()
+float32 battery_voltage

--- a/frc_msgs/package.xml
+++ b/frc_msgs/package.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>frc_msgs</name>
+  <version>0.0.0</version>
+  <description>FRC messages, such as those required to imitate the Driver Station</description>
+
+  <maintainer email="mtreynolds@uwaterloo.ca">Matt Reynolds</maintainer>
+
+  <license>BSD-3</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+</package>

--- a/frc_robot_hw/CMakeLists.txt
+++ b/frc_robot_hw/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   binary_state_controller
   ternary_state_controller
   pdp_state_controller
+  frc_msgs
 )
 
 # Declare a catkin package
@@ -36,6 +37,7 @@ catkin_package(
     binary_state_controller
     ternary_state_controller
     pdp_state_controller
+    frc_msgs
 )
 
 # Specify additional locations of header files

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
@@ -29,8 +29,13 @@
 
 #include <frc_robot_hw/frc_robot_hw.h>
 
-// WPILib driver station
+#include <frc_msgs/JoyFeedback.h>
+
+#include <thread>
+
+// WPILib headers
 #include <frc/DriverStation.h>
+#include <frc/Joystick.h>
 
 // WPILib & vendor sensors/actuators
 #include <frc/AnalogInput.h>
@@ -88,6 +93,12 @@ public:
    */
   bool initHAL();
 
+  // Overrides
+  bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) override;
+  void read(const ros::Time& time, const ros::Duration& period) override;
+  void write(const ros::Time& time, const ros::Duration& period) override;
+
+private:
   /**
    * @brief Maintain a loop to get data from the driver station.
    *
@@ -98,12 +109,8 @@ public:
    */
   void runHAL();
 
-  // Overrides
-  bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) override;
-  void read(const ros::Time& time, const ros::Duration& period) override;
-  void write(const ros::Time& time, const ros::Duration& period) override;
+  void joyFeedbackCallback(const frc_msgs::JoyFeedbackConstPtr& msg);
 
-private:
   // Maps of the WPILib objects used to interact with the HAL
   // TODO: Probably can't have generic type for smart_speed_controllers_
   std::map<std::string, std::unique_ptr<frc::SpeedController>>        smart_speed_controllers_;
@@ -127,8 +134,14 @@ private:
 #endif
 
   std::thread hal_thread_;
+  bool        robot_code_ready_ = false;
 
-  bool robot_code_ready_ = false;
+  frc::Joystick sticks_[frc::DriverStation::kJoystickPorts] {frc::Joystick(0),
+                                                             frc::Joystick(1),
+                                                             frc::Joystick(2),
+                                                             frc::Joystick(3),
+                                                             frc::Joystick(4),
+                                                             frc::Joystick(5)};
 };
 
 }  // namespace frc_robot_hw

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2018, UW REACT
+// Copyright (C) 2019, UW REACT
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -29,9 +29,17 @@
 
 #include <frc_robot_hw/frc_robot_hw.h>
 
-#include <frc_msgs/JoyFeedback.h>
-
 #include <thread>
+
+#include <realtime_tools/realtime_publisher.h>
+
+// Custom messages
+#include <frc_msgs/DriverStationMode.h>
+#include <frc_msgs/JoyArray.h>
+#include <frc_msgs/JoyFeedback.h>
+#include <frc_msgs/MatchData.h>
+#include <frc_msgs/MatchTime.h>
+#include <frc_msgs/RobotState.h>
 
 // WPILib headers
 #include <frc/DriverStation.h>
@@ -142,6 +150,16 @@ private:
                                                              frc::Joystick(3),
                                                              frc::Joystick(4),
                                                              frc::Joystick(5)};
+
+  // TODO(matt.reynolds): Make this configurable via yaml
+  ros::Duration publish_period_ {0.1};
+
+  realtime_tools::RealtimePublisher<frc_msgs::DriverStationMode> ds_mode_pub_;
+  realtime_tools::RealtimePublisher<frc_msgs::JoyArray>          joy_pub_;
+  realtime_tools::RealtimePublisher<frc_msgs::MatchData>         match_data_pub_;
+  realtime_tools::RealtimePublisher<frc_msgs::MatchTime>         match_time_pub_;
+  realtime_tools::RealtimePublisher<frc_msgs::RobotState>        robot_state_pub_;
+  ros::Subscriber                                                joy_feedback_sub_;
 };
 
 }  // namespace frc_robot_hw

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
@@ -106,6 +106,8 @@ public:
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;
 
+  inline void setPublishRate(double rate) { publish_period_ = ros::Duration(1.0 / rate); }
+
 private:
   /**
    * @brief Maintain a loop to get data from the driver station.
@@ -151,8 +153,7 @@ private:
                                                              frc::Joystick(4),
                                                              frc::Joystick(5)};
 
-  // TODO(matt.reynolds): Make this configurable via yaml
-  ros::Duration publish_period_ {0.1};
+  ros::Duration publish_period_;
 
   realtime_tools::RealtimePublisher<frc_msgs::DriverStationMode> ds_mode_pub_;
   realtime_tools::RealtimePublisher<frc_msgs::JoyArray>          joy_pub_;

--- a/frc_robot_hw/package.xml
+++ b/frc_robot_hw/package.xml
@@ -24,6 +24,7 @@
   <depend>tinyxml2</depend>
   <depend>urdf</depend>
 
+  <depend>frc_msgs</depend>
   <depend>analog_state_controller</depend>
   <depend>binary_state_controller</depend>
   <depend>ternary_state_controller</depend>

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -90,7 +90,7 @@ void FRCRobotHWReal::runHAL() {
         for (unsigned button = 0; button < ds.GetStickButtonCount(i); button++)
           stick.buttons[button] = ds.GetStickButton(i, button + 1);
 
-        // TODO(matt.reynolds): Ensure POV hat is covered. If not, either append it to buttons and axes, or add new array
+        // TODO(matt.reynolds): Ensure POV hat is covered. If not, append it to buttons[] and axes[] or add new array
         // See https://github.com/uwreact/frc_control/issues/51
 
         joy_pub_.msg_.sticks[i] = stick;

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2018, UW REACT
+// Copyright (C) 2019, UW REACT
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -31,15 +31,6 @@
 #include <frc/RobotController.h>
 #include <hal/HAL.h>
 
-// Custom messages
-#include <frc_msgs/DriverStationMode.h>
-#include <frc_msgs/JoyArray.h>
-#include <frc_msgs/MatchData.h>
-#include <frc_msgs/MatchTime.h>
-#include <frc_msgs/RobotState.h>
-
-#include <sensor_msgs/Joy.h>
-#include <std_msgs/Time.h>
 #include <tf2/LinearMath/Quaternion.h>
 
 namespace frc_robot_hw {
@@ -69,110 +60,146 @@ void FRCRobotHWReal::runHAL() {
   HAL_ObserveUserProgramStarting();
 
   frc::DriverStation& ds = frc::DriverStation::GetInstance();
+  ros::Time           time;
 
+  // We use realtime publishers here because we must publish ds_mode and joysticks deterministically since they are
+  // safety-related. We populate the messages here in the HAL thread, but punt the actual writing to the socket to
+  // another thread so that we don't delay this thread.
   while (ros::ok()) {
-    // TODO: Limit update & publish rate of match data?
 
-    // Read all joysticks
-    frc_msgs::JoyArray joys;
-    for (unsigned i = 0; i < frc::DriverStation::kJoystickPorts; i++) {
+    // Publish joysticks
+    time = ros::Time::now();
+    static ros::Time last_joy_pub_time;
+    if (!publish_period_.isZero() && last_joy_pub_time + publish_period_ < time && joy_pub_.trylock()) {
+      last_joy_pub_time          = time;
+      joy_pub_.msg_.header.stamp = time;
 
-      sensor_msgs::Joy stick;
+      for (unsigned i = 0; i < frc::DriverStation::kJoystickPorts; i++) {
 
-      stick.header.stamp = ros::Time::now();
+        sensor_msgs::Joy stick;
+        stick.header.stamp = time;
 
-      stick.axes.resize(ds.GetStickAxisCount(i));
-      for (unsigned axis = 0; axis < ds.GetStickAxisCount(i); axis++)
-        stick.axes[axis] = ds.GetStickAxis(i, axis);
+        stick.axes.resize(ds.GetStickAxisCount(i));
+        for (unsigned axis = 0; axis < ds.GetStickAxisCount(i); axis++)
+          stick.axes[axis] = ds.GetStickAxis(i, axis);
 
-      // Note: Buttons, unlike axes, are indexed from 1 rather than 0
-      stick.buttons.resize(ds.GetStickButtonCount(i));
-      for (unsigned button = 0; button < ds.GetStickButtonCount(i); button++)
-        stick.buttons[button] = ds.GetStickButton(i, button + 1);
+        // Note: Buttons, unlike axes, are indexed from 1 rather than 0
+        stick.buttons.resize(ds.GetStickButtonCount(i));
+        for (unsigned button = 0; button < ds.GetStickButtonCount(i); button++)
+          stick.buttons[button] = ds.GetStickButton(i, button + 1);
 
-      // TODO: Ensure POV hat is covered. If not, append it to axes and buttons
+        // TODO: Ensure POV hat is covered. If not, append it to axes and buttons
 
-      joys.sticks[i] = stick;
-      joys.types[i]  = ds.GetJoystickType(i);
-      joys.names[i]  = ds.GetJoystickName(i);
+        joy_pub_.msg_.sticks[i] = stick;
+        joy_pub_.msg_.types[i]  = ds.GetJoystickType(i);
+        joy_pub_.msg_.names[i]  = ds.GetJoystickName(i);
+      }
+
+      joy_pub_.unlockAndPublish();
     }
 
 
-    // Get match data
-    frc_msgs::MatchData match_data;
-    match_data.header.stamp          = ros::Time::now();
-    match_data.game_specific_message = ds.GetGameSpecificMessage();
-    match_data.event_name            = ds.GetEventName();
-    match_data.match_type            = ds.GetMatchType();  // kNone, kPractice, kQualification, kElimination
-    match_data.match_number          = ds.GetMatchNumber();
-    match_data.replay_number = ds.GetReplayNumber();  // Presumably will increment on each replay of a match, since
-                                                      // match number is no longer unique
-    match_data.alliance = ds.GetAlliance();           // kRed, kBlue, or kInvalid
-    match_data.location = ds.GetLocation();           // 1, 2, or 3. 0 if invalid
+    // Publish match data
+    time = ros::Time::now();
+    static ros::Time last_match_data_pub_time;
+    if (!publish_period_.isZero() && last_match_data_pub_time + publish_period_ < time && match_data_pub_.trylock()) {
+      last_match_data_pub_time          = time;
+      match_data_pub_.msg_.header.stamp = time;
 
-    // Get match time
+      match_data_pub_.msg_.game_specific_message = ds.GetGameSpecificMessage();
+      match_data_pub_.msg_.event_name            = ds.GetEventName();
+      match_data_pub_.msg_.match_type            = ds.GetMatchType();  // kNone, kPractice, kQualification, kElimination
+      match_data_pub_.msg_.match_number          = ds.GetMatchNumber();
+      match_data_pub_.msg_.replay_number         = ds.GetReplayNumber();
+      match_data_pub_.msg_.alliance              = ds.GetAlliance();  // kRed, kBlue, or kInvalid
+      match_data_pub_.msg_.location              = ds.GetLocation();  // 1, 2, or 3. 0 if invalid
+
+      match_data_pub_.unlockAndPublish();
+    }
+
+
+    // Publish match time
     // APPROXIMATE remaining time in current period (auto or teleop), in seconds.
     // Note: The FMS does not report official match time to robots, thus this may be imprecise.
-    frc_msgs::MatchTime match_time;
-    match_time.header.stamp   = ros::Time::now();
-    match_time.remaining_time = ds.GetMatchTime();
+    time = ros::Time::now();
+    static ros::Time last_match_time_pub_time;
+    if (!publish_period_.isZero() && last_match_time_pub_time + publish_period_ < time && match_time_pub_.trylock()) {
+      last_match_time_pub_time          = time;
+      match_time_pub_.msg_.header.stamp = time;
 
-    // Get driver station mode
-    frc_msgs::DriverStationMode ds_mode;
-    ds_mode.header.stamp = ros::Time::now();
+      match_time_pub_.msg_.remaining_time = ds.GetMatchTime();
 
-    // TODO(matt.reynolds): Estop
-    if (ds.IsDisabled())
-      ds_mode.mode = frc_msgs::DriverStationMode::MODE_DISABLED;
-    else if (ds.IsOperatorControl())
-      ds_mode.mode = frc_msgs::DriverStationMode::MODE_OPERATOR;
-    else if (ds.IsAutonomous())
-      ds_mode.mode = frc_msgs::DriverStationMode::MODE_AUTONOMOUS;
-    else if (ds.IsTest())
-      ds_mode.mode = frc_msgs::DriverStationMode::MODE_TEST;
-    else
-      ds_mode.mode = frc_msgs::DriverStationMode::MODE_DISABLED;
+      match_time_pub_.unlockAndPublish();
+    }
 
-    ds_mode.is_ds_attached  = ds.IsDSAttached();
-    ds_mode.is_fms_attached = ds.IsFMSAttached();
 
-    // Get robot state
-    frc_msgs::RobotState robot_state;
-    robot_state.header.stamp = ros::Time::now();
+    // Publish driver station mode
+    time = ros::Time::now();
+    static ros::Time last_ds_mode_pub_time;
+    if (!publish_period_.isZero() && last_ds_mode_pub_time + publish_period_ < time && ds_mode_pub_.trylock()) {
+      last_ds_mode_pub_time          = time;
+      ds_mode_pub_.msg_.header.stamp = time;
 
-    robot_state.fpga_version    = frc::RobotController::GetFPGAVersion();
-    robot_state.fpga_revision   = frc::RobotController::GetFPGARevision();
-    robot_state.fpga_time       = frc::RobotController::GetFPGATime();
-    robot_state.user_button     = frc::RobotController::GetUserButton();
-    robot_state.sys_active      = frc::RobotController::IsSysActive();
-    robot_state.browned_out     = frc::RobotController::IsBrownedOut();
-    robot_state.input_voltage   = frc::RobotController::GetInputVoltage();
-    robot_state.input_current   = frc::RobotController::GetInputCurrent();
-    robot_state.voltage_3v3     = frc::RobotController::GetVoltage3V3();
-    robot_state.current_3v3     = frc::RobotController::GetCurrent3V3();
-    robot_state.enabled_3v3     = frc::RobotController::GetEnabled3V3();
-    robot_state.fault_count_3v3 = frc::RobotController::GetFaultCount3V3();
-    robot_state.voltage_5v      = frc::RobotController::GetVoltage5V();
-    robot_state.current_5v      = frc::RobotController::GetCurrent5V();
-    robot_state.enabled_5v      = frc::RobotController::GetEnabled5V();
-    robot_state.fault_count_5v  = frc::RobotController::GetFaultCount5V();
-    robot_state.voltage_6v      = frc::RobotController::GetVoltage6V();
-    robot_state.current_6v      = frc::RobotController::GetCurrent6V();
-    robot_state.enabled_6v      = frc::RobotController::GetEnabled6V();
-    robot_state.fault_count_6v  = frc::RobotController::GetFaultCount6V();
+      // TODO(matt.reynolds): Estop
+      if (ds.IsDisabled())
+        ds_mode_pub_.msg_.mode = frc_msgs::DriverStationMode::MODE_DISABLED;
+      else if (ds.IsOperatorControl())
+        ds_mode_pub_.msg_.mode = frc_msgs::DriverStationMode::MODE_OPERATOR;
+      else if (ds.IsAutonomous())
+        ds_mode_pub_.msg_.mode = frc_msgs::DriverStationMode::MODE_AUTONOMOUS;
+      else if (ds.IsTest())
+        ds_mode_pub_.msg_.mode = frc_msgs::DriverStationMode::MODE_TEST;
+      else
+        ds_mode_pub_.msg_.mode = frc_msgs::DriverStationMode::MODE_DISABLED;
 
-    frc::CANStatus can_status                      = frc::RobotController::GetCANStatus();
-    robot_state.can_status.percent_bus_utilization = can_status.percentBusUtilization;
-    robot_state.can_status.bus_off_count           = can_status.busOffCount;
-    robot_state.can_status.tx_full_count           = can_status.txFullCount;
-    robot_state.can_status.receive_error_count     = can_status.receiveErrorCount;
-    robot_state.can_status.transmit_error_count    = can_status.transmitErrorCount;
+      ds_mode_pub_.msg_.is_ds_attached  = ds.IsDSAttached();
+      ds_mode_pub_.msg_.is_fms_attached = ds.IsFMSAttached();
 
-    robot_state.battery_voltage = ds.GetBatteryVoltage();
+      ds_mode_pub_.unlockAndPublish();
+    }
+
+
+    // Publish robot state
+    time = ros::Time::now();
+    static ros::Time last_robot_state_pub_time;
+    if (!publish_period_.isZero() && last_robot_state_pub_time + publish_period_ < time && robot_state_pub_.trylock()) {
+      last_robot_state_pub_time          = time;
+      robot_state_pub_.msg_.header.stamp = time;
+
+      robot_state_pub_.msg_.fpga_version    = frc::RobotController::GetFPGAVersion();
+      robot_state_pub_.msg_.fpga_revision   = frc::RobotController::GetFPGARevision();
+      robot_state_pub_.msg_.fpga_time       = frc::RobotController::GetFPGATime();
+      robot_state_pub_.msg_.user_button     = frc::RobotController::GetUserButton();
+      robot_state_pub_.msg_.sys_active      = frc::RobotController::IsSysActive();
+      robot_state_pub_.msg_.browned_out     = frc::RobotController::IsBrownedOut();
+      robot_state_pub_.msg_.input_voltage   = frc::RobotController::GetInputVoltage();
+      robot_state_pub_.msg_.input_current   = frc::RobotController::GetInputCurrent();
+      robot_state_pub_.msg_.voltage_3v3     = frc::RobotController::GetVoltage3V3();
+      robot_state_pub_.msg_.current_3v3     = frc::RobotController::GetCurrent3V3();
+      robot_state_pub_.msg_.enabled_3v3     = frc::RobotController::GetEnabled3V3();
+      robot_state_pub_.msg_.fault_count_3v3 = frc::RobotController::GetFaultCount3V3();
+      robot_state_pub_.msg_.voltage_5v      = frc::RobotController::GetVoltage5V();
+      robot_state_pub_.msg_.current_5v      = frc::RobotController::GetCurrent5V();
+      robot_state_pub_.msg_.enabled_5v      = frc::RobotController::GetEnabled5V();
+      robot_state_pub_.msg_.fault_count_5v  = frc::RobotController::GetFaultCount5V();
+      robot_state_pub_.msg_.voltage_6v      = frc::RobotController::GetVoltage6V();
+      robot_state_pub_.msg_.current_6v      = frc::RobotController::GetCurrent6V();
+      robot_state_pub_.msg_.enabled_6v      = frc::RobotController::GetEnabled6V();
+      robot_state_pub_.msg_.fault_count_6v  = frc::RobotController::GetFaultCount6V();
+
+      const frc::CANStatus& can_status                         = frc::RobotController::GetCANStatus();
+      robot_state_pub_.msg_.can_status.percent_bus_utilization = can_status.percentBusUtilization;
+      robot_state_pub_.msg_.can_status.bus_off_count           = can_status.busOffCount;
+      robot_state_pub_.msg_.can_status.tx_full_count           = can_status.txFullCount;
+      robot_state_pub_.msg_.can_status.receive_error_count     = can_status.receiveErrorCount;
+      robot_state_pub_.msg_.can_status.transmit_error_count    = can_status.transmitErrorCount;
+
+      robot_state_pub_.msg_.battery_voltage = ds.GetBatteryVoltage();
+
+      robot_state_pub_.unlockAndPublish();
+    }
 
     // TODO: Publish NetworkTables.
-
-    // TODO: Publish data. Use RT pub?
 
     // Wait for driver station data so the loop doesn't hog the CPU
     ds.WaitForData();
@@ -183,7 +210,8 @@ void FRCRobotHWReal::joyFeedbackCallback(const frc_msgs::JoyFeedbackConstPtr& ms
   using RumbleType = frc::GenericHID::RumbleType;
 
   if (msg->left_rumbles.size() != msg->right_rumbles.size() || msg->left_rumbles.size() != msg->outputs.size()) {
-    ROS_WARN_NAMED(name_, "Invalid joystick feeedback! Both rumble vectors and the output vector must be the same size.");
+    ROS_WARN_NAMED(name_,
+                   "Invalid joystick feeedback! Both rumble vectors and the output vector must be the same size.");
   } else if (msg->left_rumbles.size() > 6) {
     ROS_WARN_NAMED(name_, "Invalid joystick feedback! More than 6 joysticks specified.");
   } else {
@@ -202,6 +230,17 @@ bool FRCRobotHWReal::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh
 
   if (!initHAL())
     return false;
+
+  // Setup the realtime publishers
+  ds_mode_pub_.init(root_nh, "frc/ds_mode", 10);
+  joy_pub_.init(root_nh, "frc/joys", 10);
+  match_data_pub_.init(root_nh, "frc/match_data", 10);
+  match_time_pub_.init(root_nh, "frc/match_time", 10);
+  robot_state_pub_.init(root_nh, "frc/robot_state", 10);
+
+  // Setup the subscribers
+  joy_feedback_sub_ = root_nh.subscribe("frc/joy_feedback", 1, &FRCRobotHWReal::joyFeedbackCallback, this);
+
 
   // =*=*=*=*=*=*=*= Sensors =*=*=*=*=*=*=*=
 
@@ -388,7 +427,7 @@ bool FRCRobotHWReal::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh
 
     std::unique_ptr<frc::SpeedController> controller;
     switch (pair.second.type) {
-      // clang-format off
+        // clang-format off
       case Type::DMC60:         controller = std::make_unique<frc::DMC60>(id);        break;
       case Type::Jaguar:        controller = std::make_unique<frc::Jaguar>(id);       break;
       case Type::PWMTalonSRX:   controller = std::make_unique<frc::PWMTalonSRX>(id);  break;
@@ -448,8 +487,8 @@ void FRCRobotHWReal::read(const ros::Time& time, const ros::Duration& period) {
     rate_states_[pair.first].state = pair.second->GetVoltage() / 5.0 * config.scale + config.offset;
 
     // Sloppy rate calculation
-    // TODO: Use hardware rate when available (AnalogGyro). Actually, we should probably treat AnalogGyros as IMUs, and
-    // reserve AnalogInputs for pots, linear transducers, analog ultrasonics, etc.
+    // TODO: Use hardware rate when available (AnalogGyro). Actually, we should probably treat AnalogGyros as IMUs,
+    // and reserve AnalogInputs for pots, linear transducers, analog ultrasonics, etc.
     static double last_time       = ros::Time::now().toSec();
     double        cur_time        = ros::Time::now().toSec();
     rate_states_[pair.first].rate = (rate_states_[pair.first].state - last_state) / (cur_time - last_time);

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -231,6 +231,10 @@ bool FRCRobotHWReal::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh
   if (!initHAL())
     return false;
 
+  double publish_freq;
+  robot_hw_nh.param("frc_msg_publish_frequency", publish_freq, 10.0);
+  setPublishRate(publish_freq);
+
   // Setup the realtime publishers
   ds_mode_pub_.init(root_nh, "frc/ds_mode", 10);
   joy_pub_.init(root_nh, "frc/joys", 10);

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -75,6 +75,8 @@ void FRCRobotHWReal::runHAL() {
       joy_pub_.msg_.header.stamp = time;
 
       for (unsigned i = 0; i < frc::DriverStation::kJoystickPorts; i++) {
+        // NOTE(matt.reynolds): Driver station axes are shortened from double (float64)
+        // to float (float32) to be packed in sensor_msgs::Joy.
 
         sensor_msgs::Joy stick;
         stick.header.stamp = time;
@@ -88,7 +90,8 @@ void FRCRobotHWReal::runHAL() {
         for (unsigned button = 0; button < ds.GetStickButtonCount(i); button++)
           stick.buttons[button] = ds.GetStickButton(i, button + 1);
 
-        // TODO: Ensure POV hat is covered. If not, append it to axes and buttons
+        // TODO(matt.reynolds): Ensure POV hat is covered. If not, either append it to buttons and axes, or add new array
+        // See https://github.com/uwreact/frc_control/issues/51
 
         joy_pub_.msg_.sticks[i] = stick;
         joy_pub_.msg_.types[i]  = ds.GetJoystickType(i);


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
Closes #54

Adds message definitions for Driver Station/FMS-related data. In a real, hardware robot, these topics are populated and published by the base node, essentially just forwarding the data from the DS/FMS onto the rest of the system. The same node also subscribes to the joy feedback topic, which others can publish to control the joysticks.

In simulation, these messages will all be handled by the QT driver station, passing data directly from the app to the system rather than app->base node->Rest of system.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
