### PR TITLE
Add data publisher

### DIFF
--- a/driver_station/src/driver_station/publisher.py
+++ b/driver_station/src/driver_station/publisher.py
@@ -44,7 +44,7 @@ class Publisher(threading.Thread):
     """ROS Topic publishers."""
 
     def __init__(self, data):
-        threading.Thread.__init__(self)
+        super(Publisher, self).__init__()
 
         self.data = data
 

--- a/driver_station/src/driver_station/publisher.py
+++ b/driver_station/src/driver_station/publisher.py
@@ -57,10 +57,13 @@ class Publisher(threading.Thread):
         self.data.ds_mode.set_attr('is_ds_attached', True)
 
     def run(self):
-        frequency = 10
-        rate = rospy.Rate(frequency)
-        while not rospy.is_shutdown():
 
+        # Publish data at 50Hz to match the rate of the real driver station.
+        frequency = 50
+        rate = rospy.Rate(frequency)
+
+        # Loop until shutdown
+        while not rospy.is_shutdown():
             self.ds_mode_pub.publish(self.data.ds_mode.get())
             self.match_time_pub.publish(self.data.match_time.get())
             self.match_data_pub.publish(self.data.match_data.get())

--- a/driver_station/src/driver_station/widgets/communications.py
+++ b/driver_station/src/driver_station/widgets/communications.py
@@ -111,6 +111,7 @@ class CommunicationsWidget(object):
 
     def set_fms_connected(self, _, match_data):
         """Set the FMS Connected indicator based on whether the event name is set."""
+        self.data.ds_mode.set_attr('is_fms_attached', match_data.event_name != '')
         gui_utils.bool_style(self.window.fmsCommsDisplay, match_data.event_name != '')
 
     def start_periodic(self, period=100):

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -40,6 +40,7 @@ from python_qt_binding import QtWidgets
 
 # frc_control imports
 from driver_station import data
+from driver_station import publisher
 from driver_station.utils import gui_utils
 from driver_station.utils import utils
 from driver_station.widgets import communications
@@ -64,6 +65,8 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
 
         self.data = data.MainData()
+        self.pub = publisher.Publisher(self.data)
+        self.pub.start()
 
         # Setup the UI
         self.init_ui()


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

Closes #50.

The DS publishes match data (match number, event name, alliance, etc), match time, and driver station mode (disabled, teleop, auto, etc)  at a fixed rate of 50Hz, matching the rate that packets are published from the real DS.

Additionally, the DS publishes the joystick data at this same rate, but since joystick support is not yet implemented the msg is empty.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
