### PR TITLE
Add data subscriber

### DIFF
--- a/driver_station/src/driver_station/data.py
+++ b/driver_station/src/driver_station/data.py
@@ -35,6 +35,7 @@ from frc_msgs.msg import JoyArray
 from frc_msgs.msg import JoyFeedback
 from frc_msgs.msg import MatchData
 from frc_msgs.msg import MatchTime
+from frc_msgs.msg import RobotState
 
 
 class MainData(object):
@@ -58,10 +59,10 @@ class MainData(object):
         self.joy_feedback = ObservableObj(JoyFeedback())
         self.match_data = ObservableObj(MatchData())
         self.match_time = ObservableObj(MatchTime())
+        self.robot_state = ObservableObj(RobotState())
 
         # Internal state variables
         self.has_robot_comms = ObservableData(False)
         self.has_robot_code = ObservableData(False)
-        self.brownout = ObservableData(False)
         self.robot_mode = ObservableData(structs.RobotModeState.TELEOP)
         self.enable_disable = ObservableData(structs.EnableDisableState.DISABLE)

--- a/driver_station/src/driver_station/publisher.py
+++ b/driver_station/src/driver_station/publisher.py
@@ -48,10 +48,10 @@ class Publisher(threading.Thread):
 
         self.data = data
 
-        self.ds_mode_pub = rospy.Publisher('ds_mode', DriverStationMode, queue_size=10)
-        self.match_time_pub = rospy.Publisher('match_time', MatchTime, queue_size=10)
-        self.match_data_pub = rospy.Publisher('match_data', MatchData, queue_size=10)
-        self.joys_pub = rospy.Publisher('joys', JoyArray, queue_size=10)
+        self.ds_mode_pub = rospy.Publisher('/frc/ds_mode', DriverStationMode, queue_size=10)
+        self.match_time_pub = rospy.Publisher('/frc/match_time', MatchTime, queue_size=10)
+        self.match_data_pub = rospy.Publisher('/frc/match_data', MatchData, queue_size=10)
+        self.joys_pub = rospy.Publisher('/frc/joys', JoyArray, queue_size=10)
 
         # Since this app IS the driver station, is_ds_attached is always True
         self.data.ds_mode.set_attr('is_ds_attached', True)

--- a/driver_station/src/driver_station/subscriber.py
+++ b/driver_station/src/driver_station/subscriber.py
@@ -41,8 +41,8 @@ class Subscriber(object):
     def __init__(self, data):
         self.data = data
 
-        rospy.Subscriber('frc/joy_feedback', JoyFeedback, self._joy_feedback_callback)
-        rospy.Subscriber('frc/robot_state', RobotState, self._robot_state_callback)
+        rospy.Subscriber('/frc/joy_feedback', JoyFeedback, self._joy_feedback_callback)
+        rospy.Subscriber('/frc/robot_state', RobotState, self._robot_state_callback)
 
         self.callbacks = []
 

--- a/driver_station/src/driver_station/subscriber.py
+++ b/driver_station/src/driver_station/subscriber.py
@@ -51,14 +51,18 @@ class Subscriber(object):
         """Add a callback to notify when a RobotState msg is received."""
         self.callbacks.append(callback)
 
-    def _joy_feedback_callback(self, joystick_data):
-        # TODO: Rumble joysticks
-        pass
+    def _joy_feedback_callback(self, feedback_data):
+
+        # Remove the header so that observers are only notified when the actual contents of the msg change
+        feedback_data.header = None
+        self.data.joy_feedback.set(feedback_data)
 
     def _robot_state_callback(self, robot_state):
 
-        # Brownout
-        self.data.brownout = robot_state.browned_out
+        # Remove the header so that observers are only notified when the actual contents of the msg change
+        robot_state.header = None
+        self.data.robot_state.set(robot_state)
+
 
         # TODO: Write msg data to self.data observer rather than directly to the UI
 
@@ -80,5 +84,7 @@ class Subscriber(object):
         # Battery Voltage
         self.window.batteryVoltageDisplay.setText('{:0.2f}'.format(robot_state.battery_voltage))
 
+        # We use explicit callbacks here rather than relying on the robot_state observer since we want to notify
+        # whenever ANY msg is received, regardless of whether the data is changed or not.
         for callback in self.callbacks:
             callback()

--- a/driver_station/src/driver_station/subscriber.py
+++ b/driver_station/src/driver_station/subscriber.py
@@ -38,8 +38,7 @@ from frc_msgs.msg import RobotState
 class Subscriber(object):
     """ROS Topic Subscribers."""
 
-    def __init__(self, window, data):
-        self.window = window
+    def __init__(self, data):
         self.data = data
 
         rospy.Subscriber('frc/joy_feedback', JoyFeedback, self._joy_feedback_callback)
@@ -62,27 +61,6 @@ class Subscriber(object):
         # Remove the header so that observers are only notified when the actual contents of the msg change
         robot_state.header = None
         self.data.robot_state.set(robot_state)
-
-
-        # TODO: Write msg data to self.data observer rather than directly to the UI
-
-        # Faults
-        # self.window.faultsCommsDisplay.setText('?')
-        # self.window.faults12vDisplay.setText('?')
-        self.window.faults6vDisplay.setText(str(robot_state.fault_count_6v))
-        self.window.faults5vDisplay.setText(str(robot_state.fault_count_5v))
-        self.window.faults3v3Display.setText(str(robot_state.fault_count_3v3))
-
-        # CAN Metrics
-        percent_bus_utilization = int(round(robot_state.can_status.percent_bus_utilization * 100))
-        self.window.metricsUtilizationDisplay.setText(str(percent_bus_utilization))
-        self.window.metricsBusOffDisplay.setText(str(robot_state.can_status.bus_off_count))
-        self.window.metricsTxFullDisplay.setText(str(robot_state.can_status.tx_full_count))
-        self.window.metricsReceiveDisplay.setText(str(robot_state.can_status.receive_error_count))
-        self.window.metricsTransmitDisplay.setText(str(robot_state.can_status.transmit_error_count))
-
-        # Battery Voltage
-        self.window.batteryVoltageDisplay.setText('{:0.2f}'.format(robot_state.battery_voltage))
 
         # We use explicit callbacks here rather than relying on the robot_state observer since we want to notify
         # whenever ANY msg is received, regardless of whether the data is changed or not.

--- a/driver_station/src/driver_station/subscriber.py
+++ b/driver_station/src/driver_station/subscriber.py
@@ -44,11 +44,11 @@ class Subscriber(object):
         rospy.Subscriber('/frc/joy_feedback', JoyFeedback, self._joy_feedback_callback)
         rospy.Subscriber('/frc/robot_state', RobotState, self._robot_state_callback)
 
-        self.callbacks = []
+        self.robot_state_callbacks = []
 
     def add_robot_state_callback(self, callback):
-        """Add a callback to notify when a RobotState msg is received."""
-        self.callbacks.append(callback)
+        """Add a callback to notify when any RobotState msg is received."""
+        self.robot_state_callbacks.append(callback)
 
     def _joy_feedback_callback(self, feedback_data):
 
@@ -62,7 +62,7 @@ class Subscriber(object):
         robot_state.header = None
         self.data.robot_state.set(robot_state)
 
-        # We use explicit callbacks here rather than relying on the robot_state observer since we want to notify
-        # whenever ANY msg is received, regardless of whether the data is changed or not.
-        for callback in self.callbacks:
+        # Use explicit callbacks here rather than relying on the robot_state observer since we want to notify
+        # some observers whenever ANY msg is received, regardless of whether the data is changed or not.
+        for callback in self.robot_state_callbacks:
             callback()

--- a/driver_station/src/driver_station/subscriber.py
+++ b/driver_station/src/driver_station/subscriber.py
@@ -1,0 +1,84 @@
+##############################################################################
+# Copyright (C) 2019, UW REACT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of UW REACT, nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
+
+"""The Subscriber class."""
+
+# ROS imports
+import rospy
+
+# frc_control imports
+from frc_msgs.msg import JoyFeedback
+from frc_msgs.msg import RobotState
+
+
+class Subscriber(object):
+    """ROS Topic Subscribers."""
+
+    def __init__(self, window, data):
+        self.window = window
+        self.data = data
+
+        rospy.Subscriber('frc/joy_feedback', JoyFeedback, self._joy_feedback_callback)
+        rospy.Subscriber('frc/robot_state', RobotState, self._robot_state_callback)
+
+        self.callbacks = []
+
+    def add_robot_state_callback(self, callback):
+        """Add a callback to notify when a RobotState msg is received."""
+        self.callbacks.append(callback)
+
+    def _joy_feedback_callback(self, joystick_data):
+        # TODO: Rumble joysticks
+        pass
+
+    def _robot_state_callback(self, robot_state):
+
+        # Brownout
+        self.data.brownout = robot_state.browned_out
+
+        # TODO: Write msg data to self.data observer rather than directly to the UI
+
+        # Faults
+        # self.window.faultsCommsDisplay.setText('?')
+        # self.window.faults12vDisplay.setText('?')
+        self.window.faults6vDisplay.setText(str(robot_state.fault_count_6v))
+        self.window.faults5vDisplay.setText(str(robot_state.fault_count_5v))
+        self.window.faults3v3Display.setText(str(robot_state.fault_count_3v3))
+
+        # CAN Metrics
+        percent_bus_utilization = int(round(robot_state.can_status.percent_bus_utilization * 100))
+        self.window.metricsUtilizationDisplay.setText(str(percent_bus_utilization))
+        self.window.metricsBusOffDisplay.setText(str(robot_state.can_status.bus_off_count))
+        self.window.metricsTxFullDisplay.setText(str(robot_state.can_status.tx_full_count))
+        self.window.metricsReceiveDisplay.setText(str(robot_state.can_status.receive_error_count))
+        self.window.metricsTransmitDisplay.setText(str(robot_state.can_status.transmit_error_count))
+
+        # Battery Voltage
+        self.window.batteryVoltageDisplay.setText('{:0.2f}'.format(robot_state.battery_voltage))
+
+        for callback in self.callbacks:
+            callback()

--- a/driver_station/src/driver_station/widgets/battery_display.py
+++ b/driver_station/src/driver_station/widgets/battery_display.py
@@ -50,3 +50,5 @@ class BatteryDisplayWidget(object):
         """Clear the battery voltage when comms are lost."""
         if not has_comms:
             self.window.batteryVoltageDisplay.setText('--.--')
+        else:
+            self.window.batteryVoltageDisplay.setText('{:0.2f}'.format(self.data.robot_state.get().battery_voltage))

--- a/driver_station/src/driver_station/widgets/battery_display.py
+++ b/driver_station/src/driver_station/widgets/battery_display.py
@@ -1,0 +1,52 @@
+##############################################################################
+# Copyright (C) 2019, UW REACT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of UW REACT, nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
+
+"""The BatteryDisplayWidget class."""
+
+
+class BatteryDisplayWidget(object):
+    """A widget to control the robot battery voltage."""
+
+    def __init__(self, window, data):
+        self.window = window
+        self.data = data
+
+        # Register callbacks
+        self.data.robot_state.add_observer(self._update_voltage)
+        self.data.has_robot_comms.add_observer(self._update_robot_comms)
+
+        # Apply default value
+        self.window.batteryVoltageDisplay.setText('--.--')
+
+    def _update_voltage(self, _, robot_state):
+        """Update the battery voltage."""
+        self.window.batteryVoltageDisplay.setText('{:0.2f}'.format(robot_state.battery_voltage))
+
+    def _update_robot_comms(self, _, has_comms):
+        """Clear the battery voltage when comms are lost."""
+        if not has_comms:
+            self.window.batteryVoltageDisplay.setText('--.--')

--- a/driver_station/src/driver_station/widgets/major_status.py
+++ b/driver_station/src/driver_station/widgets/major_status.py
@@ -45,8 +45,6 @@ class MajorStatusWidget(object):
      - Communications: Whether the DS is currently communicating with the roboRIO
      - Robot Code: Whether the team Robot Code is currently running on the roboRIO
      - Joysticks: Whether at least one joystick is plugged in and detected by the DS
-
-    Temporary: Also handles clearing the battery voltage once comms are lost.
     """
 
     def __init__(self, window, data):
@@ -94,8 +92,6 @@ class MajorStatusWidget(object):
         else:
             if 'RIO' in self.data.versions.get_all():
                 self.data.versions.delete('RIO')
-
-        self.window.batteryVoltageDisplay.setText('--.--')
 
     def _has_robot_code(self, has_code):
         """Update the robot code indicator with the new state."""

--- a/driver_station/src/driver_station/widgets/metrics.py
+++ b/driver_station/src/driver_station/widgets/metrics.py
@@ -1,0 +1,57 @@
+##############################################################################
+# Copyright (C) 2019, UW REACT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of UW REACT, nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
+
+"""The MetricsWidget class."""
+
+
+class MetricsWidget(object):
+    """A widget to control the power, faults, and CAN metrics."""
+
+    def __init__(self, window, data):
+        self.window = window
+        self.data = data
+
+        # Register callback
+        self.data.robot_state.add_observer(self._update)
+
+    def _update(self, _, robot_state):
+        """Update the metrics."""
+
+        # Faults
+        # self.window.faultsCommsDisplay.setText('?')
+        # self.window.faults12vDisplay.setText('?')
+        self.window.faults6vDisplay.setText(str(robot_state.fault_count_6v))
+        self.window.faults5vDisplay.setText(str(robot_state.fault_count_5v))
+        self.window.faults3v3Display.setText(str(robot_state.fault_count_3v3))
+
+        # CAN Metrics
+        percent_bus_utilization = int(round(robot_state.can_status.percent_bus_utilization * 100))
+        self.window.metricsUtilizationDisplay.setText(str(percent_bus_utilization))
+        self.window.metricsBusOffDisplay.setText(str(robot_state.can_status.bus_off_count))
+        self.window.metricsTxFullDisplay.setText(str(robot_state.can_status.tx_full_count))
+        self.window.metricsReceiveDisplay.setText(str(robot_state.can_status.receive_error_count))
+        self.window.metricsTransmitDisplay.setText(str(robot_state.can_status.transmit_error_count))

--- a/driver_station/src/driver_station/widgets/status_string.py
+++ b/driver_station/src/driver_station/widgets/status_string.py
@@ -61,6 +61,7 @@ class StatusStringWidget(object):
         # Since the robot_state is updated far more freqently than the browned_out state,
         # only update the UI when the value changes.
         self.brownout = self.data.robot_state.get().browned_out
+
         def _brownout_cb(_, robot_state):
             if robot_state.browned_out == self.brownout:
                 return
@@ -68,7 +69,6 @@ class StatusStringWidget(object):
             self._update_string()
 
         self.data.robot_state.add_observer(_brownout_cb)
-
         self.data.has_robot_comms.add_observer(self._update_string)
         self.data.has_robot_code.add_observer(self._update_string)
         self.data.robot_mode.add_observer(self._update_string)

--- a/driver_station/src/driver_station/widgets/status_string.py
+++ b/driver_station/src/driver_station/widgets/status_string.py
@@ -58,9 +58,19 @@ class StatusStringWidget(object):
         self.window = window
         self.data = data
 
+        # Since the robot_state is updated far more freqently than the browned_out state,
+        # only update the UI when the value changes.
+        self.brownout = self.data.robot_state.get().browned_out
+        def _brownout_cb(_, robot_state):
+            if robot_state.browned_out == self.brownout:
+                return
+            self.brownout = robot_state.browned_out
+            self._update_string()
+
+        self.data.robot_state.add_observer(_brownout_cb)
+
         self.data.has_robot_comms.add_observer(self._update_string)
         self.data.has_robot_code.add_observer(self._update_string)
-        self.data.brownout.add_observer(self._update_string)
         self.data.robot_mode.add_observer(self._update_string)
         self.data.enable_disable.add_observer(self._update_string)
 
@@ -94,7 +104,7 @@ class StatusStringWidget(object):
             self.window.statusStringDisplay.setText(StatusStrings.NO_CODE.value)
         elif self.data.enable_disable.get() == structs.EnableDisableState.ESTOP:
             self.window.statusStringDisplay.setText(StatusStrings.ESTOP.value)
-        elif self.data.brownout.get():
+        elif self.brownout:
             self.window.statusStringDisplay.setText(StatusStrings.BROWNOUT.value)
         else:
 

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -49,6 +49,7 @@ from driver_station.widgets import communications
 from driver_station.widgets import joystick_indicator
 from driver_station.widgets import major_status
 from driver_station.widgets import match_data
+from driver_station.widgets import metrics
 from driver_station.widgets import pc_stats
 from driver_station.widgets import practice_timing
 from driver_station.widgets import rio_utils
@@ -82,6 +83,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.joystick_indicator = joystick_indicator.JoystickIndicatorWidget(self)
         self.major_status = major_status.MajorStatusWidget(self, self.data)
         self.match_data = match_data.MatchDataWidget(self, self.data)
+        self.metrics = metrics.MetricsWidget(self, self.data)
         self.pc_stats = pc_stats.PcStatsWidget(self)
         self.practice_timing = practice_timing.PracticeTimingWidget(self, self.data)
         self.rio_utils = rio_utils.RioUtilsWidget(self, self.data)

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -69,7 +69,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         self.data = data.MainData()
         self.pub = publisher.Publisher(self.data)
-        self.sub = subscriber.Subscriber(self, self.data)
+        self.sub = subscriber.Subscriber(self.data)
 
         # Start the publisher
         self.pub.start()

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -40,6 +40,7 @@ from python_qt_binding import QtWidgets
 
 # frc_control imports
 from driver_station import data
+from driver_station import subscriber
 from driver_station.utils import gui_utils
 from driver_station.utils import utils
 from driver_station.widgets import communications
@@ -64,6 +65,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.setWindowFlags(QtCore.Qt.WindowStaysOnTopHint)
 
         self.data = data.MainData()
+        self.sub = subscriber.Subscriber(self, self.data)
 
         # Setup the UI
         self.init_ui()
@@ -79,6 +81,9 @@ class MainWindow(QtWidgets.QMainWindow):
         self.robot_mode = robot_mode.RobotModeWidget(self, self.data)
         self.status_string = status_string.StatusStringWidget(self, self.data)
         self.time_display = time_display.TimeDisplayWidget(self, self.data)
+
+        # Feed the Robot Code indicator's watchdog whenever the subscriber receives data from the robot
+        self.sub.add_robot_state_callback(self.major_status.watchdog.feed)
 
         # Register callbacks
         self.data.versions.add_observer(self.update_versions)

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -44,6 +44,7 @@ from driver_station import publisher
 from driver_station import subscriber
 from driver_station.utils import gui_utils
 from driver_station.utils import utils
+from driver_station.widgets import battery_display
 from driver_station.widgets import communications
 from driver_station.widgets import joystick_indicator
 from driver_station.widgets import major_status
@@ -76,6 +77,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.init_ui()
 
         # Setup all the inner widgets
+        self.battery_display = battery_display.BatteryDisplayWidget(self, self.data)
         self.communications = communications.CommunicationsWidget(self, self.data)
         self.joystick_indicator = joystick_indicator.JoystickIndicatorWidget(self)
         self.major_status = major_status.MajorStatusWidget(self, self.data)


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

Closes #53.

Adds data subscribers for RobotState (battery voltage, faults, CAN metrics, etc) and for JoyFeedback (joystick rumble). RobotState data is displayed on the UI, JoyFeedback data is currently unused since joysticks are not yet supported.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
