### PR TITLE
Add joystick support to DS

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -2,3 +2,4 @@
 based_on_style = pep8
 column_limit = 120
 blank_line_before_module_docstring = true
+blank_line_before_nested_class_or_def = true

--- a/driver_station/resources/layout/driver-station.ui
+++ b/driver_station/resources/layout/driver-station.ui
@@ -1018,7 +1018,8 @@ p, li { white-space: pre-wrap; }
             <property name="icon">
              <iconset>
               <normaloff>../icons/baseline-volume_off-24px.svg</normaloff>
-              <normalon>../icons/baseline-volume_up-24px.svg</normalon>../icons/baseline-volume_off-24px.svg</iconset>
+              <normalon>../icons/baseline-volume_up-24px.svg</normalon>
+             </iconset>
             </property>
             <property name="iconSize">
              <size>

--- a/driver_station/resources/layout/driver-station.ui
+++ b/driver_station/resources/layout/driver-station.ui
@@ -1017,9 +1017,8 @@ p, li { white-space: pre-wrap; }
            <widget class="QPushButton" name="enableSoundButton">
             <property name="icon">
              <iconset>
-              <normalon>../icons/baseline-volume_up-24px.svg</normalon>
               <normaloff>../icons/baseline-volume_off-24px.svg</normaloff>
-             </iconset>
+              <normalon>../icons/baseline-volume_up-24px.svg</normalon>../icons/baseline-volume_off-24px.svg</iconset>
             </property>
             <property name="iconSize">
              <size>
@@ -1171,56 +1170,6 @@ p, li { white-space: pre-wrap; }
          <layout class="QGridLayout" name="deviceIndicatorFrame">
           <item row="1" column="1" rowspan="3">
            <layout class="QGridLayout" name="buttonsIndicatorFrame">
-            <item row="1" column="0" alignment="Qt::AlignRight">
-             <widget class="QLineEdit" name="button0Display">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>15</width>
-                <height>15</height>
-               </size>
-              </property>
-              <property name="cursor">
-               <cursorShape>ArrowCursor</cursorShape>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="1" alignment="Qt::AlignLeft">
-             <widget class="QLineEdit" name="button9Display">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>15</width>
-                <height>15</height>
-               </size>
-              </property>
-              <property name="cursor">
-               <cursorShape>ArrowCursor</cursorShape>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
             <item row="0" column="0" colspan="2">
              <widget class="QLabel" name="buttonsIndicatorFrameTitle">
               <property name="font">
@@ -1233,58 +1182,8 @@ p, li { white-space: pre-wrap; }
               </property>
              </widget>
             </item>
-            <item row="6" column="0" alignment="Qt::AlignRight">
-             <widget class="QLineEdit" name="button5Display">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>15</width>
-                <height>15</height>
-               </size>
-              </property>
-              <property name="cursor">
-               <cursorShape>ArrowCursor</cursorShape>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="4" column="0" alignment="Qt::AlignRight">
-             <widget class="QLineEdit" name="button3Display">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>15</width>
-                <height>15</height>
-               </size>
-              </property>
-              <property name="cursor">
-               <cursorShape>ArrowCursor</cursorShape>
-              </property>
-              <property name="focusPolicy">
-               <enum>Qt::NoFocus</enum>
-              </property>
-              <property name="readOnly">
-               <bool>true</bool>
-              </property>
-             </widget>
-            </item>
-            <item row="8" column="0" alignment="Qt::AlignRight">
-             <widget class="QLineEdit" name="button7Display">
+            <item row="1" column="0" alignment="Qt::AlignRight">
+             <widget class="QLineEdit" name="button0Display">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1333,8 +1232,33 @@ p, li { white-space: pre-wrap; }
               </property>
              </widget>
             </item>
-            <item row="1" column="1" alignment="Qt::AlignLeft">
-             <widget class="QLineEdit" name="button8Display">
+            <item row="3" column="0" alignment="Qt::AlignRight">
+             <widget class="QLineEdit" name="button2Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="0" alignment="Qt::AlignRight">
+             <widget class="QLineEdit" name="button3Display">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1383,21 +1307,8 @@ p, li { white-space: pre-wrap; }
               </property>
              </widget>
             </item>
-            <item row="9" column="0">
-             <spacer name="verticalSpacer_13">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item row="3" column="0" alignment="Qt::AlignRight">
-             <widget class="QLineEdit" name="button2Display">
+            <item row="6" column="0" alignment="Qt::AlignRight">
+             <widget class="QLineEdit" name="button5Display">
               <property name="sizePolicy">
                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                 <horstretch>0</horstretch>
@@ -1445,6 +1356,244 @@ p, li { white-space: pre-wrap; }
                <bool>true</bool>
               </property>
              </widget>
+            </item>
+            <item row="8" column="0" alignment="Qt::AlignRight">
+             <widget class="QLineEdit" name="button7Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button8Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button9Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button10Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="4" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button11Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="5" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button12Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="6" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button13Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="7" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button14Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="8" column="1" alignment="Qt::AlignLeft">
+             <widget class="QLineEdit" name="button15Display">
+              <property name="sizePolicy">
+               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                <horstretch>0</horstretch>
+                <verstretch>0</verstretch>
+               </sizepolicy>
+              </property>
+              <property name="maximumSize">
+               <size>
+                <width>15</width>
+                <height>15</height>
+               </size>
+              </property>
+              <property name="cursor">
+               <cursorShape>ArrowCursor</cursorShape>
+              </property>
+              <property name="focusPolicy">
+               <enum>Qt::NoFocus</enum>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+             </widget>
+            </item>
+            <item row="9" column="1">
+             <spacer name="verticalSpacer_13">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
             </item>
            </layout>
           </item>

--- a/driver_station/src/driver_station/data.py
+++ b/driver_station/src/driver_station/data.py
@@ -62,6 +62,8 @@ class MainData(object):
         self.robot_state = ObservableObj(RobotState())
 
         # Internal state variables
+        self.joystick_mappings = ObservableDict()
+        self.selected_joystick = ObservableData(0)
         self.has_robot_comms = ObservableData(False)
         self.has_robot_code = ObservableData(False)
         self.robot_mode = ObservableData(structs.RobotModeState.TELEOP)

--- a/driver_station/src/driver_station/data.py
+++ b/driver_station/src/driver_station/data.py
@@ -63,7 +63,7 @@ class MainData(object):
 
         # Internal state variables
         self.joystick_mappings = ObservableDict()
-        self.selected_joystick = ObservableData(0)
+        self.selected_joystick = ObservableData(-1)
         self.has_robot_comms = ObservableData(False)
         self.has_robot_code = ObservableData(False)
         self.robot_mode = ObservableData(structs.RobotModeState.TELEOP)

--- a/driver_station/src/driver_station/joysticks.py
+++ b/driver_station/src/driver_station/joysticks.py
@@ -1,0 +1,133 @@
+##############################################################################
+# Copyright (C) 2019, UW REACT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of UW REACT, nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##############################################################################c
+
+"""The Joystick and JoystickUpdater classes."""
+
+# Standard imports
+import array
+import os
+import struct
+import threading
+from fcntl import ioctl
+
+# ROS imports
+import rospy
+from sensor_msgs.msg import Joy
+
+# frc_control imports
+from frc_msgs.msg import JoyArray
+
+# Extracted from <linux/joystick.h>
+LINUX_INPUT_MACROS = {
+    'JSIOCGAXES': 0x80016A11,
+    'JSIOCGBUTTONS': 0x80016A12,
+    'JSIOCGNAME': lambda len: 0x80016A13 + (0x10000 * len)
+}
+
+
+class Joystick(object):
+    """A Linux joystick wrapper."""
+
+    def __init__(self, dev):
+        self.devfile = dev
+        self.eventfile = None
+
+        devnum = int(self.devfile.split('js')[1])
+        for dev_dirs in os.listdir('/sys/class/input/js{}/device'.format(devnum)):
+            if dev_dirs.startswith('event'):
+                self.eventfile = '/dev/input/' + dev_dirs
+
+        self.jsdev = open(self.devfile, 'rb')
+        if self.eventfile is not None:
+            self.eventdev = open(self.eventfile, 'rb')
+
+    @staticmethod
+    def detect_sticks():
+        """Detect up to 6 available joysticks."""
+        joystick_devs = [fn for fn in os.listdir('/dev/input') if fn.startswith('js')]
+        return ['/dev/input/' + fn for fn in joystick_devs[:6]]
+
+    def get_num_axes(self):
+        """Get the number of axes."""
+        buf = array.array('B', [0])
+        ioctl(self.jsdev, LINUX_INPUT_MACROS['JSIOCGAXES'], buf)
+        return buf[0]
+
+    def get_num_buttons(self):
+        """Get the number of buttons."""
+        buf = array.array('B', [0])
+        ioctl(self.jsdev, LINUX_INPUT_MACROS['JSIOCGBUTTONS'], buf)
+        return buf[0]
+
+    def get_name(self, maxlen=64):
+        """Get the identifier string."""
+        buf = array.array('c', ['\0'] * maxlen)
+        ioctl(self.jsdev, LINUX_INPUT_MACROS['JSIOCGNAME'](len(buf)), buf)
+        return buf.tostring()
+
+    def get_state(self):
+        """Get the current state of the joystick, as a sensor_msgs/Joy."""
+        joy = Joy()
+        joy.axes = [0] * self.get_num_axes()
+        joy.buttons = [0] * self.get_num_buttons()
+
+        # Close and re-open the file to load the initial values.
+        # TODO: This is slow. Instead, keep the file open and listen for events
+        self.jsdev.close()
+        self.jsdev = open(self.devfile, 'rb')
+
+        for _ in range(0, self.get_num_axes() + self.get_num_buttons()):
+            buf = self.jsdev.read(8)
+            _time, value, val_type, number = struct.unpack('IhBB', buf)
+
+            if val_type & 0x01:
+                joy.buttons[number] = value
+
+            if val_type & 0x02:
+                joy.axes[number] = value / 32767.0
+
+        return joy
+
+
+class JoystickUpdater(threading.Thread):
+    """Thread to update joystick states."""
+
+    def __init__(self, data, joys=None):
+        super(JoystickUpdater, self).__init__()
+        self.data = data
+        self.joys = joys or [Joystick(f) for f in Joystick.detect_sticks()]
+
+    def run(self):
+        # Loop until shutdown
+        # TODO: Limit rate?
+        while not rospy.is_shutdown():
+            msg = JoyArray()
+            for stick in self.joys:
+                msg.sticks.append(stick.get_state())
+                msg.names.append(stick.get_name())
+
+            self.data.joys.set(msg)

--- a/driver_station/src/driver_station/joysticks.py
+++ b/driver_station/src/driver_station/joysticks.py
@@ -277,7 +277,7 @@ class Joystick(object):
 class JoystickManager(threading.Thread):
     """Thread to update joystick states."""
 
-    def __init__(self, data, joys=None):
+    def __init__(self, data):
         super(JoystickManager, self).__init__()
         self.data = data
         self.rescan()

--- a/driver_station/src/driver_station/joysticks.py
+++ b/driver_station/src/driver_station/joysticks.py
@@ -25,7 +25,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 ##############################################################################c
 
-"""The Joystick and JoystickUpdater classes."""
+"""The Joystick and JoystickManager classes."""
 
 # Standard imports
 import array
@@ -71,12 +71,6 @@ class Joystick(object):
         # Load initial state
         self.uuid = self.get_uuid()
         self.state = self.get_state()
-
-    @staticmethod
-    def detect_sticks():
-        """Detect up to 6 available joysticks."""
-        joystick_devs = [fn for fn in sorted(os.listdir('/dev/input')) if fn.startswith('js')]
-        return ['/dev/input/' + fn for fn in joystick_devs[:6]]
 
     def close(self):
         """Close the device files."""
@@ -190,7 +184,10 @@ class JoystickManager(threading.Thread):
     def rescan(self):
         """Reload the available joysticks."""
 
-        self.joys = [Joystick(f) for f in Joystick.detect_sticks()]
+        # Detect and load up to 6 available joysticks
+        # TODO: Ensure that all locked joysticks are loaded, even if more than 6 joysticks are detected
+        devfiles = [fn for fn in sorted(os.listdir('/dev/input')) if fn.startswith('js')]
+        self.joys = [Joystick('/dev/input/' + fn) for fn in devfiles[:6]]
 
         mappings = self.data.joystick_mappings.get_all()
         uuids = mappings.keys()

--- a/driver_station/src/driver_station/structs.py
+++ b/driver_station/src/driver_station/structs.py
@@ -56,3 +56,16 @@ class PracticeTiming(object):
         self.delay = 1
         self.teleop = 100
         self.endgame = 20
+
+
+class JoystickInfo(object):
+    """Data structure containing the durations of each stage of practice mode."""
+
+    # TODO: Change to a dict to be more pythonic? Or wait for py3.7 @dataclass?
+
+    def __init__(self):
+        self.index = 0
+        self.name = 1
+        self.locked = False
+        self.axis_names = []
+        self.btn_names = []

--- a/driver_station/src/driver_station/utils/gui_utils.py
+++ b/driver_station/src/driver_station/utils/gui_utils.py
@@ -64,6 +64,13 @@ def bool_style(element, enabled, use_red=False):
         element.setStyleSheet('background-color: #{:06x}'.format(color_disabled))
 
 
+def set_underlined(element, underlined):
+    """Set whether the specified element should use an underlined font or not."""
+    f = element.font()
+    f.setUnderline(underlined)
+    element.setFont(f)
+
+
 def setup_int_validator(element, fixup, lower=0, upper=2**31 - 1):
     """Setup an int validator for the specified element.
 

--- a/driver_station/src/driver_station/utils/observable.py
+++ b/driver_station/src/driver_station/utils/observable.py
@@ -101,14 +101,20 @@ class ObservableData(Observable):
         if self._val == new_val:
             return
 
-        self._val = new_val
+        self._val = copy.deepcopy(new_val)
         self.set_changed()
-        self.notify_observers(self._val)
+        self.notify_observers()
         self.clear_changed()
 
     def get(self):
         """Get the stored value."""
         return copy.deepcopy(self._val)
+
+    def force_notify(self, arg=None):
+        super(ObservableData, self).force_notify(arg or self._val)
+
+    def notify_observers(self, arg=None):
+        super(ObservableData, self).notify_observers(arg or self._val)
 
 
 class ObservableObj(ObservableData):
@@ -121,7 +127,7 @@ class ObservableObj(ObservableData):
 
         setattr(self._val, attr, new_val)
         self.set_changed()
-        self.notify_observers(self._val)
+        self.notify_observers()
         self.clear_changed()
 
 
@@ -159,3 +165,9 @@ class ObservableDict(Observable):
     def get_all(self):
         """Get the stored value."""
         return copy.deepcopy(self._dict)
+
+    def force_notify(self, arg=None):
+        super(ObservableDict, self).force_notify(arg or self._dict)
+
+    def notify_observers(self, arg=None):
+        super(ObservableDict, self).notify_observers(arg or self._dict)

--- a/driver_station/src/driver_station/widgets/joystick_indicator.py
+++ b/driver_station/src/driver_station/widgets/joystick_indicator.py
@@ -33,7 +33,7 @@ from sensor_msgs.msg import Joy
 
 # frc_control imports
 from driver_station.utils import gui_utils
-from frc_msgs.msg import JoyArray
+# from frc_msgs.msg import JoyArray
 
 
 class JoystickIndicatorWidget(object):
@@ -47,7 +47,7 @@ class JoystickIndicatorWidget(object):
 
         self.timer = QtCore.QTimer(window)
         self.timer.timeout.connect(self._update)
-        self.timer.start(10) # 100Hz
+        self.timer.start(10)  # 100Hz
         self._clear()
 
     def _clear(self):
@@ -73,11 +73,11 @@ class JoystickIndicatorWidget(object):
         self.joy_state = joy_state
 
         # TODO: Support up to JoyArray.MAX_JOYSTICK_XXX indicators?
-        MAX_AXES = 6  #JoyArray.MAX_JOYSTICK_AXES
-        MAX_BTNS = 16  #JoyArray.MAX_JOYSTICK_BUTTONS
+        max_axes = 6  #JoyArray.MAX_JOYSTICK_AXES
+        max_btns = 16  #JoyArray.MAX_JOYSTICK_BUTTONS
 
-        joy_state.axes = joy_state.axes[:MAX_AXES]
-        joy_state.buttons = joy_state.buttons[:MAX_BTNS]
+        joy_state.axes = joy_state.axes[:max_axes]
+        joy_state.buttons = joy_state.buttons[:max_btns]
 
         stick_mappings = self.data.joystick_mappings.get_all()
         info = None
@@ -92,7 +92,7 @@ class JoystickIndicatorWidget(object):
             axis_display.setVisible(True)
             axis_display.setValue(axis * 100)
 
-        for i in range(len(joy_state.axes), MAX_AXES):
+        for i in range(len(joy_state.axes), max_axes):
             axis_display = getattr(self.window, 'axis{}Display'.format(i))
             axis_display.setVisible(False)
 
@@ -103,6 +103,6 @@ class JoystickIndicatorWidget(object):
             btn_display.setVisible(True)
             gui_utils.bool_style(btn_display, btn > 0)
 
-        for i in range(len(joy_state.buttons), MAX_BTNS):
+        for i in range(len(joy_state.buttons), max_btns):
             btn_display = getattr(self.window, 'button{}Display'.format(i))
             btn_display.setVisible(False)

--- a/driver_station/src/driver_station/widgets/joystick_indicator.py
+++ b/driver_station/src/driver_station/widgets/joystick_indicator.py
@@ -55,11 +55,10 @@ class JoystickIndicatorWidget(object):
         self._update_state(empty_joy)
 
     def _update(self):
-
         joy_array = self.data.joys.get()
         idx = self.data.selected_joystick.get()
 
-        if len(joy_array.sticks) <= idx:
+        if idx < 0 or len(joy_array.sticks) <= idx:
             self._clear()
             return
 
@@ -80,8 +79,16 @@ class JoystickIndicatorWidget(object):
         joy_state.axes = joy_state.axes[:MAX_AXES]
         joy_state.buttons = joy_state.buttons[:MAX_BTNS]
 
+        stick_mappings = self.data.joystick_mappings.get_all()
+        info = None
+        for mapping in stick_mappings.values():
+            if mapping.index == self.data.selected_joystick.get():
+                info = mapping
+
         for i, axis in enumerate(joy_state.axes):
             axis_display = getattr(self.window, 'axis{}Display'.format(i))
+            if info is not None:
+                axis_display.setFormat('{}: {}'.format(i, info.axis_names[i]))
             axis_display.setVisible(True)
             axis_display.setValue(axis * 100)
 
@@ -91,6 +98,8 @@ class JoystickIndicatorWidget(object):
 
         for i, btn in enumerate(joy_state.buttons):
             btn_display = getattr(self.window, 'button{}Display'.format(i))
+            if info is not None:
+                btn_display.setToolTip('{}: {}'.format(i, info.btn_names[i]))
             btn_display.setVisible(True)
             gui_utils.bool_style(btn_display, btn > 0)
 

--- a/driver_station/src/driver_station/widgets/joystick_selector.py
+++ b/driver_station/src/driver_station/widgets/joystick_selector.py
@@ -1,0 +1,130 @@
+##############################################################################
+# Copyright (C) 2019, UW REACT
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#   * Redistributions of source code must retain the above copyright notice,
+#     this list of conditions and the following disclaimer.
+#   * Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#   * Neither the name of UW REACT, nor the names of its
+#     contributors may be used to endorse or promote products derived from
+#     this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+##############################################################################
+
+"""The JoystickSelectorWidget class."""
+
+# ROS imports
+from python_qt_binding import QtCore
+from python_qt_binding import QtGui
+from python_qt_binding import QtWidgets
+
+# frc_control imports
+from driver_station.utils import gui_utils
+
+
+class JoystickSelectorWidget(object):
+    """A widget to reorder joysticks."""
+
+    def __init__(self, window, data):
+        self.window = window
+        self.data = data
+
+        self.init_ui()
+
+        self.stick_names = []
+        self.data.joystick_mappings.add_observer(self._update_sticks)
+        self.data.joystick_mappings.force_notify()
+
+    def init_ui(self):
+        """Setup the UI elements."""
+
+        self.window.usbSetupList.currentRowChanged.connect(self._update_selection)
+        self.window.usbSetupList.itemDoubleClicked.connect(self._toggle_locked)
+        self.window.usbSetupList.model().rowsMoved.connect(self._update_rows)
+        self.window.usbSetupList.setDragDropMode(QtWidgets.QAbstractItemView.InternalMove)
+
+        self.window.rescanUsbButton.clicked.connect(self.window.joys.rescan)
+
+    def _update_rows(self, _1, source, _2, _3, dest):
+
+        # Update joystick mappings
+        if dest < source:
+            for i in range(dest, source + 1):
+                uuid = self.window.usbSetupList.item(i).data(QtCore.Qt.UserRole)
+                if uuid is None:
+                    self.window.usbSetupList.item(i).setText('{} ----'.format(i))
+                else:
+                    data = list(self.data.joystick_mappings.get(uuid))
+                    data[0] = i
+                    if i == dest:
+                        data[2] = True
+
+                    self.data.joystick_mappings.set(uuid, data)
+                    gui_utils.set_underlined(self.window.usbSetupList.item(i), data[2])
+                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, data[1]))
+
+        if dest > source:
+            for i in range(source, dest):
+                uuid = self.window.usbSetupList.item(i).data(QtCore.Qt.UserRole)
+
+                if uuid is None:
+                    self.window.usbSetupList.item(i).setText('{} ----'.format(i))
+                else:
+                    data = list(self.data.joystick_mappings.get(uuid))
+                    data[0] = i
+                    if i == dest - 1:
+                        data[2] = True
+
+                    self.data.joystick_mappings.set(uuid, data)
+                    gui_utils.set_underlined(self.window.usbSetupList.item(i), data[2])
+                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, data[1]))
+
+        self.data.selected_joystick.set(self.window.usbSetupList.currentRow())
+
+    def _toggle_locked(self, item):
+        uuid = item.data(QtCore.Qt.UserRole)
+        if uuid is None:
+            return
+
+        data = list(self.data.joystick_mappings.get(uuid))
+        data[2] = not data[2]
+        self.data.joystick_mappings.set(uuid, data)
+        gui_utils.set_underlined(item, data[2])
+
+    def _update_sticks(self, _, sticks):
+        empty_sticks = range(0, 6)
+
+        # Display the active and locked sticks
+        for uuid, data in sticks.items():
+            idx = data[0]
+            empty_sticks.remove(idx)
+            name = data[1]
+            locked = data[2]
+            gui_utils.set_underlined(self.window.usbSetupList.item(idx), locked)
+            self.window.usbSetupList.item(idx).setText('{} {}'.format(idx, name))
+            self.window.usbSetupList.item(idx).setData(QtCore.Qt.UserRole, uuid)
+
+        # Clear out the empty sticks
+        for i in empty_sticks:
+            gui_utils.set_underlined(self.window.usbSetupList.item(i), False)
+            self.window.usbSetupList.item(i).setText('{} ----'.format(i))
+            self.window.usbSetupList.item(i).setData(QtCore.Qt.UserRole, None)
+
+        self.data.selected_joystick.set(self.window.usbSetupList.currentRow())
+
+    def _update_selection(self, row):
+        self.data.selected_joystick.set(row)

--- a/driver_station/src/driver_station/widgets/joystick_selector.py
+++ b/driver_station/src/driver_station/widgets/joystick_selector.py
@@ -29,7 +29,6 @@
 
 # ROS imports
 from python_qt_binding import QtCore
-from python_qt_binding import QtGui
 from python_qt_binding import QtWidgets
 
 # frc_control imports

--- a/driver_station/src/driver_station/widgets/joystick_selector.py
+++ b/driver_station/src/driver_station/widgets/joystick_selector.py
@@ -68,14 +68,14 @@ class JoystickSelectorWidget(object):
                 if uuid is None:
                     self.window.usbSetupList.item(i).setText('{} ----'.format(i))
                 else:
-                    data = list(self.data.joystick_mappings.get(uuid))
-                    data[0] = i
+                    info = self.data.joystick_mappings.get(uuid)
+                    info.index = i
                     if i == dest:
-                        data[2] = True
+                        info.locked = True
 
-                    self.data.joystick_mappings.set(uuid, data)
-                    gui_utils.set_underlined(self.window.usbSetupList.item(i), data[2])
-                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, data[1]))
+                    self.data.joystick_mappings.set(uuid, info)
+                    gui_utils.set_underlined(self.window.usbSetupList.item(i), info.locked)
+                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, info.name))
 
         if dest > source:
             for i in range(source, dest):
@@ -84,14 +84,14 @@ class JoystickSelectorWidget(object):
                 if uuid is None:
                     self.window.usbSetupList.item(i).setText('{} ----'.format(i))
                 else:
-                    data = list(self.data.joystick_mappings.get(uuid))
-                    data[0] = i
+                    info = self.data.joystick_mappings.get(uuid)
+                    info.index = i
                     if i == dest - 1:
-                        data[2] = True
+                        info.locked = True
 
-                    self.data.joystick_mappings.set(uuid, data)
-                    gui_utils.set_underlined(self.window.usbSetupList.item(i), data[2])
-                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, data[1]))
+                    self.data.joystick_mappings.set(uuid, info)
+                    gui_utils.set_underlined(self.window.usbSetupList.item(i), info.locked)
+                    self.window.usbSetupList.item(i).setText('{} {}'.format(i, info.name))
 
         self.data.selected_joystick.set(self.window.usbSetupList.currentRow())
 
@@ -100,23 +100,20 @@ class JoystickSelectorWidget(object):
         if uuid is None:
             return
 
-        data = list(self.data.joystick_mappings.get(uuid))
-        data[2] = not data[2]
-        self.data.joystick_mappings.set(uuid, data)
-        gui_utils.set_underlined(item, data[2])
+        info = self.data.joystick_mappings.get(uuid)
+        info.locked = not info.locked
+        self.data.joystick_mappings.set(uuid, info)
+        gui_utils.set_underlined(item, info.locked)
 
     def _update_sticks(self, _, sticks):
         empty_sticks = range(0, 6)
 
         # Display the active and locked sticks
-        for uuid, data in sticks.items():
-            idx = data[0]
-            empty_sticks.remove(idx)
-            name = data[1]
-            locked = data[2]
-            gui_utils.set_underlined(self.window.usbSetupList.item(idx), locked)
-            self.window.usbSetupList.item(idx).setText('{} {}'.format(idx, name))
-            self.window.usbSetupList.item(idx).setData(QtCore.Qt.UserRole, uuid)
+        for uuid, info in sticks.items():
+            empty_sticks.remove(info.index)
+            gui_utils.set_underlined(self.window.usbSetupList.item(info.index), info.locked)
+            self.window.usbSetupList.item(info.index).setText('{} {}'.format(info.index, info.name))
+            self.window.usbSetupList.item(info.index).setData(QtCore.Qt.UserRole, uuid)
 
         # Clear out the empty sticks
         for i in empty_sticks:

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -40,6 +40,7 @@ from python_qt_binding import QtWidgets
 
 # frc_control imports
 from driver_station import data
+from driver_station import joysticks
 from driver_station import publisher
 from driver_station import subscriber
 from driver_station.utils import gui_utils
@@ -70,9 +71,11 @@ class MainWindow(QtWidgets.QMainWindow):
         self.data = data.MainData()
         self.pub = publisher.Publisher(self.data)
         self.sub = subscriber.Subscriber(self.data)
+        self.joys = joysticks.JoystickUpdater(self.data)
 
-        # Start the publisher
+        # Start the publisher and joystick threads
         self.pub.start()
+        self.joys.start()
 
         # Setup the UI
         self.init_ui()

--- a/driver_station/src/driver_station/window.py
+++ b/driver_station/src/driver_station/window.py
@@ -48,6 +48,7 @@ from driver_station.utils import utils
 from driver_station.widgets import battery_display
 from driver_station.widgets import communications
 from driver_station.widgets import joystick_indicator
+from driver_station.widgets import joystick_selector
 from driver_station.widgets import major_status
 from driver_station.widgets import match_data
 from driver_station.widgets import metrics
@@ -71,7 +72,7 @@ class MainWindow(QtWidgets.QMainWindow):
         self.data = data.MainData()
         self.pub = publisher.Publisher(self.data)
         self.sub = subscriber.Subscriber(self.data)
-        self.joys = joysticks.JoystickUpdater(self.data)
+        self.joys = joysticks.JoystickManager(self.data)
 
         # Start the publisher and joystick threads
         self.pub.start()
@@ -83,7 +84,8 @@ class MainWindow(QtWidgets.QMainWindow):
         # Setup all the inner widgets
         self.battery_display = battery_display.BatteryDisplayWidget(self, self.data)
         self.communications = communications.CommunicationsWidget(self, self.data)
-        self.joystick_indicator = joystick_indicator.JoystickIndicatorWidget(self)
+        self.joystick_indicator = joystick_indicator.JoystickIndicatorWidget(self, self.data)
+        self.joystick_selector = joystick_selector.JoystickSelectorWidget(self, self.data)
         self.major_status = major_status.MajorStatusWidget(self, self.data)
         self.match_data = match_data.MatchDataWidget(self, self.data)
         self.metrics = metrics.MetricsWidget(self, self.data)
@@ -99,7 +101,7 @@ class MainWindow(QtWidgets.QMainWindow):
 
         # Register callbacks
         self.data.versions.add_observer(self.update_versions)
-        self.data.versions.force_notify(self.data.versions.get_all())
+        self.data.versions.force_notify()
 
         # Set initial values
         # TODO: Load previous values from save file


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

Adds the ability to read and publish joystick data from the driver station. Note that this does *not* yet fully close issue #51, since POV hats are not robustly supported. There are also missing features such as autodetecting changes to the number of joysticks (ie. detecting when a joystick is plugged in or unplugged) and there are edge cases where behaviour is not fully implemented (ie. when more than 6 joysticks are connected to the computer).

That said, this PR supports joysticks well enough that I think it's worth merging in.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
