### PR TITLE
Update list of cross-compiled packages

### DIFF
--- a/installation/INSTALLATION.md
+++ b/installation/INSTALLATION.md
@@ -63,10 +63,10 @@ Download the latest Linux release from [the WPILib GitHub](https://github.com/wp
 
 ## 3. Select the packages to install
 
-This list of packages ~~may~~**will** change as time goes on. Right now, the standard robot set of packages contains many unneeded packages and adds a lot of unnecessary dependencies. Once development of this project proceeds further, we can further customize this as required. In fact, we might consider only installing the dependencies of frc_control with no additional packages. This does mean that teams who wish to run their whole ROS stack on the RIO (Instead of the recommended config; frc_control on the RIO, everything else on other machines) will be required to either manually install their extra dependencies, or clone them into their workspace. Needs some consideration.
+This list of packages may change as time goes on. Right now, the standard robot set of packages contains many unneeded packages and adds a lot of unnecessary dependencies. Once development of this project proceeds further, we can further customize this as required. In fact, we might consider only installing the dependencies of frc_control with no additional packages. This does mean that teams who wish to run their whole ROS stack on the RIO (Instead of the recommended config; frc_control on the RIO, everything else on other machines) will be required to either manually install their extra dependencies, or clone them into their workspace. Needs some consideration.
 
     sudo apt install python-rosinstall-generator python-wstool
-    rosinstall_generator robot ros_control ros_controllers realtime_tools --rosdistro melodic --deps --wet-only --tar > melodic-roborio-wet.rosinstall # Install robot plus any other dependencies
+    rosinstall_generator robot ros_control ros_controllers --exclude rqt_joint_trajectory_controller gazebo_ros --rosdistro melodic --deps --wet-only --tar > melodic-roborio-wet.rosinstall
     wstool init -j8 src melodic-roborio-wet.rosinstall
 
 ## 4. Manually resolve dependencies


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

Addresses the first issue in #66. Excludes `gazebo_ros` and `rqt_joint_trajectory_controller` from the cross-compilation, which consequently removes the dependency on `gazebo` and `qt`.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
