### PR TITLE
Cascading PID

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -327,8 +327,14 @@ Key|Type|Required?|Value/Description
     up to main controller itself, namely the roboRIO.
  - For all control modes other than voltage, we require an additional PID
     controller be specified to drive the motor with the specified command.
-    **TODO:** This isn't yet implemented, meaning only voltage control is
-    currently available.
+    This cascading PID is handled internally. However, PID gains for each
+    control mode being used (position, velocity, and effort) must be specified.
+    If gains are not specified for one of the control modes, that joint cannot
+    be controlled in that mode.
+ - For each control mode's set of gains, if one of `p`, `i`, `d`, or `f` are
+    not specified, they default to 0. If `i_clamp` is not specified, the integral
+    term is not clamped. Note that there is no feed forward term `f` in position
+    control.
  - **Current->Effort scaling:**
     - Current is proportional to effort (either force or torque), allowing us
       to use the PDP along with the robot geometry/gearing to get effort
@@ -350,8 +356,9 @@ Key|Type|Required?|Value/Description
 `pdp`|string|optional, default='none'|The name of the PDP powering this motor controller **TODO: Default to PDP ID0 rather than none**
 `pdp_ch`|int|optional|The channel of the PDP powering this motor controller
 `k_eff`|float|optional, default=`1.0`|The current to effort scaling
-
-
+`position_gains`|dict|optional|The tunings for position control: `{p: 1.0, i: 0.1, d: 0.1, i_clamp: 1.0}`
+`velocity_gains`|dict|optional|The tunings for velocity control: `{p: 1.0, i: 0.1, d: 0.1, f: 1.0, i_clamp: 1.0}`
+`effort_gains`|dict|optional|The tunings for effort control: `{p: 1.0, i: 0.1, d: 0.1, f: 1.0, i_clamp: 1.0}`
 ### 7.1.1 Nidec Brushless
  - The `NidecBrushless` is identical to the simple speed controllers described
    above, but takes and additional YAML parameter:

--- a/frc_robot_hw/CMakeLists.txt
+++ b/frc_robot_hw/CMakeLists.txt
@@ -67,6 +67,7 @@ endif()
 add_library(${PROJECT_NAME}
   src/frc_robot_hw.cpp
   src/robot_control_loop.cpp
+  src/pid_controller.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
@@ -241,6 +241,8 @@ private:
                                 const bool                       warn_exist = true,
                                 const bool                       warn_type  = true);
 
+  hardware_template::PIDGains parsePIDGains(XmlRpc::XmlRpcValue& value);
+
   /**
    * @brief Get TypeInt and TypeDouble XmlRpcValues as doubles
    *

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
@@ -1,5 +1,5 @@
 ///////////////////////////////////////////////////////////////////////////////
-// Copyright (C) 2018, UW REACT
+// Copyright (C) 2019, UW REACT
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions are met:
@@ -143,7 +143,7 @@ public:
   virtual bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) override;
   virtual void read(const ros::Time& time, const ros::Duration& period) override;
   virtual void write(const ros::Time& time, const ros::Duration& period) override;
-  void         doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+  virtual void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
                         const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
   /// Enforce limits for all values before writing.

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw_real.h
@@ -28,6 +28,7 @@
 #pragma once
 
 #include <frc_robot_hw/frc_robot_hw.h>
+#include <frc_robot_hw/pid_controller.h>
 
 #include <thread>
 
@@ -105,6 +106,8 @@ public:
   bool init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) override;
   void read(const ros::Time& time, const ros::Duration& period) override;
   void write(const ros::Time& time, const ros::Duration& period) override;
+  void doSwitch(const std::list<hardware_interface::ControllerInfo>& start_list,
+                const std::list<hardware_interface::ControllerInfo>& stop_list) override;
 
   inline void setPublishRate(double rate) { publish_period_ = ros::Duration(1.0 / rate); }
 
@@ -125,6 +128,7 @@ private:
   // TODO: Probably can't have generic type for smart_speed_controllers_
   std::map<std::string, std::unique_ptr<frc::SpeedController>>        smart_speed_controllers_;
   std::map<std::string, std::unique_ptr<frc::SpeedController>>        simple_speed_controllers_;
+  std::map<std::string, std::unique_ptr<MultiPIDController>>          simple_speed_controller_pids_;
   std::map<std::string, std::unique_ptr<frc::PowerDistributionPanel>> pdps_;
   std::map<std::string, std::unique_ptr<frc::Servo>>                  servos_;
   std::map<std::string, std::unique_ptr<frc::Relay>>                  relays_;

--- a/frc_robot_hw/include/frc_robot_hw/pid_controller.h
+++ b/frc_robot_hw/include/frc_robot_hw/pid_controller.h
@@ -38,7 +38,7 @@ public:
   enum class Mode { disabled, position, velocity, effort };
 
   MultiPIDController(const PIDGains& pos, const PIDGains& vel, const PIDGains& eff)
-      : position_gains_(pos), velocity_gains_(vel), effort_gains_(eff), cur_gains_(nullptr) {
+      : cur_gains_(nullptr), position_gains_(pos), velocity_gains_(vel), effort_gains_(eff) {
     reset();
   }
 

--- a/frc_robot_hw/include/frc_robot_hw/pid_controller.h
+++ b/frc_robot_hw/include/frc_robot_hw/pid_controller.h
@@ -1,0 +1,69 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <frc_robot_hw/wpilib_hardware_templates.h>
+
+namespace frc_robot_hw {
+
+class MultiPIDController {
+public:
+  using PIDGains = hardware_template::PIDGains;
+
+  enum class Mode { disabled, position, velocity, effort };
+
+  MultiPIDController(const PIDGains& pos, const PIDGains& vel, const PIDGains& eff)
+      : position_gains_(pos), velocity_gains_(vel), effort_gains_(eff), cur_gains_(nullptr) {
+    reset();
+  }
+
+  bool setMode(Mode mode);
+  bool setMode(const std::string& mode);
+
+  void reset();
+
+  void  setSetpoint(float sp);
+  void  update(float input);
+  float getOutput(float input);
+  float getOutput() const;
+
+private:
+  float setpoint_;
+  float integral_;
+  float last_error_;
+  bool  is_first_;
+  float output_;
+
+  Mode      mode_      = Mode::position;
+  PIDGains* cur_gains_ = nullptr;  // TODO: Smart ptr
+  PIDGains  position_gains_;
+  PIDGains  velocity_gains_;
+  PIDGains  effort_gains_;
+};
+
+}  // namespace frc_robot_hw

--- a/frc_robot_hw/include/frc_robot_hw/pid_controller.h
+++ b/frc_robot_hw/include/frc_robot_hw/pid_controller.h
@@ -47,7 +47,7 @@ public:
 
   void reset();
 
-  void  setSetpoint(float sp);
+  void  setSetpoint(float setpoint);
   void  update(float input);
   float getOutput(float input);
   float getOutput() const;

--- a/frc_robot_hw/include/frc_robot_hw/wpilib_hardware_templates.h
+++ b/frc_robot_hw/include/frc_robot_hw/wpilib_hardware_templates.h
@@ -36,6 +36,15 @@
 namespace frc_robot_hw {
 namespace hardware_template {
 
+struct PIDGains {
+  double k_p;
+  double k_i;
+  double k_d;
+  double k_f;
+  double i_clamp;
+  bool   has_i_clamp;
+};
+
 // "Smart" indicates that these controllers have built-in feedback
 // TODO: Might need custom templates for these since they're smart and therefore have more config data
 // TODO: Add field for feedback type. Internal, External, or None
@@ -162,13 +171,19 @@ struct SimpleSpeedController {
     }
   }
 
-  Type        type;      ///< The type of the controller, corresponding with WPILib & vendor SpeedControllers
-  int         id;        ///< The ID/channel of the controller. Can be PWM channel or CAN id, based on controller type
-  int         dio_id;    ///< Only used by Nidec. The DIO channel
-  bool        inverted;  ///< Whether to invert the direction of the motor
-  std::string pdp;       ///< Name of PDP. Must be "none" or the name of one of the PDPs
-  int         pdp_ch;    ///< Which PDP channel the motor controller is connected to. Used for current draw measurement
-  double      k_eff;     ///< Scale of current to effort/torque, in N or Nm. Based on motor type and gearing.
+  Type        type;       ///< The type of the controller, corresponding with WPILib & vendor SpeedControllers
+  int         id;         ///< The ID/channel of the controller. Can be PWM channel or CAN id, based on controller type
+  int         dio_id;     ///< Only used by Nidec. The DIO channel
+  bool        inverted;   ///< Whether to invert the direction of the motor
+  std::string pdp;        ///< Name of PDP. Must be "none" or the name of one of the PDPs
+  int         pdp_ch;     ///< Which PDP channel the motor controller is connected to. Used for current draw measurement
+  double      k_eff;      ///< Scale of current to effort/torque, in N or Nm. Based on motor type and gearing.
+  PIDGains    pos_gains;  ///< The set of PID gains for position control
+  PIDGains    vel_gains;  ///< The set of PID gains for velocity control
+  PIDGains    eff_gains;  ///< The set of PID gains for effort control
+  bool        has_pos_gains;  ///< Whether the controller specified gains for position control
+  bool        has_vel_gains;  ///< Whether the controller specified gains for velocity control
+  bool        has_eff_gains;  ///< Whether the controller specified gains for effort control
 };
 
 struct Relay {

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -471,7 +471,7 @@ bool FRCRobotHW::validateJointParamMember(XmlRpc::XmlRpcValue&             value
 hardware_template::PIDGains FRCRobotHW::parsePIDGains(XmlRpc::XmlRpcValue& value) {
   using XmlValue = XmlRpc::XmlRpcValue;
 
-  hardware_template::PIDGains gains;
+  hardware_template::PIDGains gains = {};
   gains.k_p = validateJointParamMember(value, "p", XmlValue::TypeDouble, false, true)
                     ? getXmlRpcDouble(value["p"]) : 0.0;
   gains.k_i = validateJointParamMember(value, "i", XmlValue::TypeDouble, false, true)

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -546,13 +546,18 @@ bool FRCRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
                                                       &joint_states_[pair.first].eff);
     joint_state_interface_.registerHandle(state_handle);
 
-    // TODO: Only register pos, vel, effort cmds if the controller a) has a feedback device and b) has PID tunings
-    joint_position_command_interface_.registerHandle(
-        hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
-    joint_velocity_command_interface_.registerHandle(
-        hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
-    joint_effort_command_interface_.registerHandle(
-        hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
+    // TODO: Only register pos, vel, effort handles if the controller has a feedback device?
+    if (pair.second.has_pos_gains)
+      joint_position_command_interface_.registerHandle(
+          hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
+
+    if (pair.second.has_vel_gains)
+      joint_velocity_command_interface_.registerHandle(
+          hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
+
+    if (pair.second.has_eff_gains)
+      joint_effort_command_interface_.registerHandle(
+          hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
     joint_voltage_command_interface_.registerHandle(
         hardware_interface::JointHandle(state_handle, &(joint_commands_[pair.first].data)));
   }

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -471,17 +471,22 @@ bool FRCRobotHW::validateJointParamMember(XmlRpc::XmlRpcValue&             value
 hardware_template::PIDGains FRCRobotHW::parsePIDGains(XmlRpc::XmlRpcValue& value) {
   using XmlValue = XmlRpc::XmlRpcValue;
 
-  hardware_template::PIDGains gains;
-  gains.k_p = validateJointParamMember(value, "p", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["p"])
-                                                                                      : 0.0;
-  gains.k_i = validateJointParamMember(value, "i", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["i"])
-                                                                                      : 0.0;
-  gains.k_d = validateJointParamMember(value, "d", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["d"])
-                                                                                      : 0.0;
-  gains.k_f = validateJointParamMember(value, "f", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["f"])
-                                                                                      : 0.0;
-  gains.has_i_clamp = validateJointParamMember(value, "i_clamp", XmlValue::TypeDouble, false, true);
-  gains.i_clamp     = gains.has_i_clamp ? getXmlRpcDouble(value["i_clamp"]) : 0.0;
+  hardware_template::PIDGains gains = {
+      .k_p = validateJointParamMember(value, "p", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["p"])
+                                                                                     : 0.0,
+      .k_i = validateJointParamMember(value, "i", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["i"])
+                                                                                     : 0.0,
+      .k_d = validateJointParamMember(value, "d", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["d"])
+                                                                                     : 0.0,
+      .k_f = validateJointParamMember(value, "f", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["f"])
+                                                                                     : 0.0,
+      .i_clamp     = 0.0,
+      .has_i_clamp = validateJointParamMember(value, "i_clamp", XmlValue::TypeDouble, false, true),
+  };
+
+  if (gains.has_i_clamp) {
+    gains.i_clamp = getXmlRpcDouble(value["i_clamp"]);
+  }
 
   return gains;
 }

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -471,17 +471,17 @@ bool FRCRobotHW::validateJointParamMember(XmlRpc::XmlRpcValue&             value
 hardware_template::PIDGains FRCRobotHW::parsePIDGains(XmlRpc::XmlRpcValue& value) {
   using XmlValue = XmlRpc::XmlRpcValue;
 
-  hardware_template::PIDGains gains = {};
-  gains.k_p = validateJointParamMember(value, "p", XmlValue::TypeDouble, false, true)
-                    ? getXmlRpcDouble(value["p"]) : 0.0;
-  gains.k_i = validateJointParamMember(value, "i", XmlValue::TypeDouble, false, true)
-                    ? getXmlRpcDouble(value["i"]) : 0.0;
-  gains.k_d = validateJointParamMember(value, "d", XmlValue::TypeDouble, false, true)
-                    ? getXmlRpcDouble(value["d"]) : 0.0;
-  gains.k_f = validateJointParamMember(value, "f", XmlValue::TypeDouble, false, true)
-                    ? getXmlRpcDouble(value["f"]) : 0.0;
+  hardware_template::PIDGains gains;
+  gains.k_p = validateJointParamMember(value, "p", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["p"])
+                                                                                      : 0.0;
+  gains.k_i = validateJointParamMember(value, "i", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["i"])
+                                                                                      : 0.0;
+  gains.k_d = validateJointParamMember(value, "d", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["d"])
+                                                                                      : 0.0;
+  gains.k_f = validateJointParamMember(value, "f", XmlValue::TypeDouble, false, true) ? getXmlRpcDouble(value["f"])
+                                                                                      : 0.0;
   gains.has_i_clamp = validateJointParamMember(value, "i_clamp", XmlValue::TypeDouble, false, true);
-  gains.i_clamp = gains.has_i_clamp ? getXmlRpcDouble(value["i_clamp"]) : 0.0;
+  gains.i_clamp     = gains.has_i_clamp ? getXmlRpcDouble(value["i_clamp"]) : 0.0;
 
   return gains;
 }

--- a/frc_robot_hw/src/pid_controller.cpp
+++ b/frc_robot_hw/src/pid_controller.cpp
@@ -36,6 +36,7 @@ bool MultiPIDController::setMode(Mode mode) {
   switch (mode_) {
     case Mode::disabled:
       cur_gains_ = nullptr;
+      break;
     case Mode::position:
       cur_gains_ = &position_gains_;
       break;

--- a/frc_robot_hw/src/pid_controller.cpp
+++ b/frc_robot_hw/src/pid_controller.cpp
@@ -1,0 +1,128 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <frc_robot_hw/pid_controller.h>
+#include <ros/time.h>
+
+namespace frc_robot_hw {
+
+bool MultiPIDController::setMode(Mode mode) {
+  mode_ = mode;
+
+  switch (mode_) {
+    case Mode::disabled:
+      cur_gains_ = nullptr;
+    case Mode::position:
+      cur_gains_ = &position_gains_;
+      break;
+    case Mode::velocity:
+      cur_gains_ = &velocity_gains_;
+      break;
+    case Mode::effort:
+      cur_gains_ = &effort_gains_;
+      break;
+      // No default case
+  }
+
+  reset();
+  return true;
+}
+
+bool MultiPIDController::setMode(const std::string& mode) {
+  if (mode == "disabled" || mode == "Disabled")
+    return setMode(Mode::disabled);
+  else if (mode == "position" || mode == "Position")
+    return setMode(Mode::position);
+  else if (mode == "velocity" || mode == "Velocity")
+    return setMode(Mode::velocity);
+  else if (mode == "effort" || mode == "Effort")
+    return setMode(Mode::effort);
+  else
+    return false;
+}
+
+void MultiPIDController::reset() {
+  integral_   = 0.0;
+  last_error_ = 0.0;
+  is_first_   = true;
+  output_     = 0.0;
+}
+
+void MultiPIDController::setSetpoint(float setpoint) {
+  setpoint_ = setpoint;
+}
+
+void MultiPIDController::update(float input) {
+  if (mode_ == Mode::disabled)
+    return;
+
+  float error = setpoint_ - input;
+
+  // Calculate time step
+  // TODO: Pass in time step?
+  static ros::Time last_time;
+  ros::Time        cur_time;
+  ros::ros_steadytime(cur_time.sec, cur_time.nsec);
+  const ros::Duration step = last_time - cur_time;
+
+  // When the controller is first enabled (or after a mode switch), set error = 0
+  if (is_first_) {
+    error     = 0.0;
+    is_first_ = false;
+  }
+
+  // Calculate integral term
+  integral_ += cur_gains_->k_i * error * step.toSec();
+  if (cur_gains_->has_i_clamp && integral_ > cur_gains_->i_clamp)
+    integral_ = cur_gains_->i_clamp;
+  else if (cur_gains_->has_i_clamp && integral_ < -cur_gains_->has_i_clamp)
+    integral_ = -cur_gains_->i_clamp;
+
+  // Calculate output
+  float ff_term = cur_gains_->k_f * setpoint_;  // TODO: Plus intercept
+  float p_term  = cur_gains_->k_p * error;
+  float i_term  = integral_;
+  float d_term  = cur_gains_->k_d * (error - last_error_) / step.toSec();
+  output_       = ff_term + p_term + i_term + d_term;
+
+  last_error_ = error;
+  last_time   = cur_time;
+}
+
+float MultiPIDController::getOutput() const {
+  if (mode_ != Mode::disabled)
+    return output_;
+  else
+    return 0.0;
+}
+
+float MultiPIDController::getOutput(float input) {
+  update(input);
+  return getOutput();
+}
+
+}  // namespace frc_robot_hw

--- a/frc_robot_hw/src/pid_controller.cpp
+++ b/frc_robot_hw/src/pid_controller.cpp
@@ -55,14 +55,13 @@ bool MultiPIDController::setMode(Mode mode) {
 bool MultiPIDController::setMode(const std::string& mode) {
   if (mode == "disabled" || mode == "Disabled")
     return setMode(Mode::disabled);
-  else if (mode == "position" || mode == "Position")
+  if (mode == "position" || mode == "Position")
     return setMode(Mode::position);
-  else if (mode == "velocity" || mode == "Velocity")
+  if (mode == "velocity" || mode == "Velocity")
     return setMode(Mode::velocity);
-  else if (mode == "effort" || mode == "Effort")
+  if (mode == "effort" || mode == "Effort")
     return setMode(Mode::effort);
-  else
-    return false;
+  return false;
 }
 
 void MultiPIDController::reset() {
@@ -99,7 +98,7 @@ void MultiPIDController::update(float input) {
   integral_ += cur_gains_->k_i * error * step.toSec();
   if (cur_gains_->has_i_clamp && integral_ > cur_gains_->i_clamp)
     integral_ = cur_gains_->i_clamp;
-  else if (cur_gains_->has_i_clamp && integral_ < -cur_gains_->has_i_clamp)
+  else if (cur_gains_->has_i_clamp && integral_ < -cur_gains_->i_clamp)
     integral_ = -cur_gains_->i_clamp;
 
   // Calculate output
@@ -114,10 +113,9 @@ void MultiPIDController::update(float input) {
 }
 
 float MultiPIDController::getOutput() const {
-  if (mode_ != Mode::disabled)
-    return output_;
-  else
+  if (mode_ == Mode::disabled)
     return 0.0;
+  return output_;
 }
 
 float MultiPIDController::getOutput(float input) {


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->

Adds general structure for internal PID controllers for cascading PID on voltage-controlled (simple) motor controllers.

 - Add syntax for specifying PID gains to yaml config file
 - Add PID gain switching on hardware interface change (ie different gains for pos, vel, & effort control)
 - Use PID controller to calculate output value, in volts, for the motors
 - Control whether to register command handles for specific hardware interfaces based on whether gains for that interface are specified.

The actual PID controller is untested and probably has bugs. However. the main intent of this PR is to get the structure of parsing gains from the file, switching between different gains as the hardware interface changes, and using the controller to calculate the output. This will set us up for adding smart speed controllers.

Debugging and fixing the real PID controllers will happen once we have a physical test fixture to debug with. Since we only use smart speed controllers in our robots, this is not critical and can therefore be pushed back and deprioritized slightly.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
