### PR TITLE
Remove useless pylint suppression

### DIFF
--- a/driver_station/scripts/driver_station
+++ b/driver_station/scripts/driver_station
@@ -32,7 +32,7 @@
 import sys
 import rospy
 from python_qt_binding.QtWidgets import QApplication
-from driver_station.window import MainWindow  # pylint: disable=no-name-in-module
+from driver_station.window import MainWindow
 
 
 def main():


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
Removes an unnecessary pylint suppression from `driver_station`.

When the ROS environment isn't sourced, pylint complains about this `import` since the `driver_station` entry script is separate from the main `driver_station` code. However, since the environment is always sourced when pylint is run (it has to be - If it isn't, pylint complains about every ROS import), this is a useless suppression.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
