### PR TITLE
Enforce strict parameter name matching

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -68,4 +68,8 @@ CheckOptions:
     value:  UPPER_CASE
   - key:    readability-identifier-naming.GlobalVariableCase
     value:  UPPER_CASE
+
+  # Ensure parameters are named exactly identical
+  - key:    readability-inconsistent-declaration-parameter-name.Strict
+    value:  1
 ...

--- a/analog_controller/include/analog_controller/analog_command_controller.h
+++ b/analog_controller/include/analog_controller/analog_command_controller.h
@@ -50,9 +50,9 @@ public:
   AnalogCommandController() = default;
   ~AnalogCommandController() { sub_command_.shutdown(); }
 
-  bool init(hardware_interface::AnalogCommandInterface* hw, ros::NodeHandle& n) override;
-  void starting(const ros::Time& /*time*/) override;
-  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override;
+  bool init(hardware_interface::AnalogCommandInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
   hardware_interface::AnalogCommandHandle joint_;

--- a/analog_controller/src/analog_command_controller.cpp
+++ b/analog_controller/src/analog_command_controller.cpp
@@ -30,19 +30,19 @@
 
 namespace analog_controller {
 
-bool AnalogCommandController::init(hardware_interface::AnalogCommandInterface* hw, ros::NodeHandle& n) {
+bool AnalogCommandController::init(hardware_interface::AnalogCommandInterface* hw, ros::NodeHandle& nh) {
   std::string joint_name;
-  if (!n.getParam("joint", joint_name)) {
-    ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
+  if (!nh.getParam("joint", joint_name)) {
+    ROS_ERROR("No joint given (namespace: %s)", nh.getNamespace().c_str());
     return false;
   }
   joint_ = hw->getHandle(joint_name);
 
-  if (!n.getParam("default", default_val_)) {
+  if (!nh.getParam("default", default_val_)) {
     default_val_ = 0.0;
   }
 
-  sub_command_ = n.subscribe<std_msgs::Float64>("command", 1, &AnalogCommandController::commandCallback, this);
+  sub_command_ = nh.subscribe<std_msgs::Float64>("command", 1, &AnalogCommandController::commandCallback, this);
   return true;
 }
 

--- a/binary_controller/include/binary_controller/binary_command_controller.h
+++ b/binary_controller/include/binary_controller/binary_command_controller.h
@@ -50,9 +50,9 @@ public:
   BinaryCommandController() = default;
   ~BinaryCommandController() { sub_command_.shutdown(); }
 
-  bool init(hardware_interface::BinaryCommandInterface* hw, ros::NodeHandle& n) override;
-  void starting(const ros::Time& /*time*/) override;
-  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override;
+  bool init(hardware_interface::BinaryCommandInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
   hardware_interface::BinaryCommandHandle joint_;

--- a/binary_controller/src/binary_command_controller.cpp
+++ b/binary_controller/src/binary_command_controller.cpp
@@ -30,19 +30,19 @@
 
 namespace binary_controller {
 
-bool BinaryCommandController::init(hardware_interface::BinaryCommandInterface* hw, ros::NodeHandle& n) {
+bool BinaryCommandController::init(hardware_interface::BinaryCommandInterface* hw, ros::NodeHandle& nh) {
   std::string joint_name;
-  if (!n.getParam("joint", joint_name)) {
-    ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
+  if (!nh.getParam("joint", joint_name)) {
+    ROS_ERROR("No joint given (namespace: %s)", nh.getNamespace().c_str());
     return false;
   }
   joint_ = hw->getHandle(joint_name);
 
-  if (!n.getParam("default", default_val_)) {
+  if (!nh.getParam("default", default_val_)) {
     default_val_ = false;
   }
 
-  sub_command_ = n.subscribe<std_msgs::Bool>("command", 1, &BinaryCommandController::commandCallback, this);
+  sub_command_ = nh.subscribe<std_msgs::Bool>("command", 1, &BinaryCommandController::commandCallback, this);
   return true;
 }
 

--- a/ternary_controller/include/ternary_controller/ternary_command_controller.h
+++ b/ternary_controller/include/ternary_controller/ternary_command_controller.h
@@ -56,9 +56,9 @@ public:
   TernaryCommandController() = default;
   ~TernaryCommandController() { sub_command_.shutdown(); }
 
-  bool init(hardware_interface::TernaryCommandInterface* hw, ros::NodeHandle& n) override;
-  void starting(const ros::Time& /*time*/) override;
-  void update(const ros::Time& /*time*/, const ros::Duration& /*period*/) override;
+  bool init(hardware_interface::TernaryCommandInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
   hardware_interface::TernaryCommandHandle     joint_;

--- a/ternary_controller/src/ternary_command_controller.cpp
+++ b/ternary_controller/src/ternary_command_controller.cpp
@@ -29,16 +29,16 @@
 #include <ternary_controller/ternary_command_controller.h>
 
 namespace ternary_controller {
-bool TernaryCommandController::init(hardware_interface::TernaryCommandInterface* hw, ros::NodeHandle& n) {
+bool TernaryCommandController::init(hardware_interface::TernaryCommandInterface* hw, ros::NodeHandle& nh) {
   std::string joint_name;
-  if (!n.getParam("joint", joint_name)) {
-    ROS_ERROR("No joint given (namespace: %s)", n.getNamespace().c_str());
+  if (!nh.getParam("joint", joint_name)) {
+    ROS_ERROR("No joint given (namespace: %s)", nh.getNamespace().c_str());
     return false;
   }
   joint_ = hw->getHandle(joint_name);
 
   int def;
-  if (!n.getParam("default", def)) {
+  if (!nh.getParam("default", def)) {
     def = 0;
   }
 
@@ -50,7 +50,7 @@ bool TernaryCommandController::init(hardware_interface::TernaryCommandInterface*
     default_val_ = TernaryState::kOff;
   }
 
-  sub_command_ = n.subscribe<std_msgs::Int8>("command", 1, &TernaryCommandController::commandCallback, this);
+  sub_command_ = nh.subscribe<std_msgs::Int8>("command", 1, &TernaryCommandController::commandCallback, this);
   return true;
 }
 


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
`readability-inconsistent-declaration-parameter-name.Strict` defaults to 0, which allows parameters to be case-insensitive prefix/suffixes of eachother (ie `count` and `count_input`). Setting `Strict` to 1 forces the parameters to be identical or absent, which is prefereable for us.

Additionally, this PR fixes related issues in `analog`, `binary`, and `ternary_controller`s.
 - Specify all parameter names in header files. Only comment out unused parameters in source files. This brings these three packages in line with the rest of the codebase.
 - Rename node handle parameter from `n` to `nh`. Must have been a typo that got copied and pasted.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
