### PR TITLE
Compressor data

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -371,12 +371,16 @@ Key|Type|Required?|Value/Description
 These objects do not specify a URDF sensor; they are YAML only.
 
 ## 1. Compressor
- - The current state is stored in a `BinaryStateHandle`, tracking whether the
-    compressor is in closed-loop control or not. **TODO: Implement custom
-    state, as with the PDP, to also track current pressure switch and
-    current draw**
+ - The current state is stored in a `CompressorStateHandle`, tracking:
+    - If closed-loop control is enabled
+    - If the compressor output is active
+    - If the pressure switch is triggered (pressure is low)
+    - Current draw
+    - If the output has been disabled due to high current draw
+    - If the output has been disabled due to a short circuit
+    - If the output does not appear to be wired
  - The next command (enable/disable closed-loop control) is stored in a
-    `BinaryCommandHandle`
+    `CompressorCommandHandle`
 #### YAML Syntax:
 Key|Type|Required?|Value/Description
 ---|----|---------|-----------------

--- a/compressor_controller/CMakeLists.txt
+++ b/compressor_controller/CMakeLists.txt
@@ -1,0 +1,69 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(compressor_controller)
+
+# Load catkin and package dependencies
+find_package(catkin REQUIRED COMPONENTS
+  controller_interface
+  hardware_interface
+  message_generation
+  pluginlib
+  realtime_tools
+  roscpp
+  std_msgs
+)
+
+add_message_files(
+   FILES
+   CompressorData.msg
+)
+
+generate_messages(
+   DEPENDENCIES
+   std_msgs
+)
+
+# Declare a catkin package
+catkin_package(
+   INCLUDE_DIRS include
+   LIBRARIES ${PROJECT_NAME}
+   CATKIN_DEPENDS
+    controller_interface
+    hardware_interface
+    message_runtime
+    pluginlib
+    realtime_tools
+    roscpp
+    std_msgs
+)
+
+# Specify additional locations of header files
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+)
+
+# Compile the plugin
+add_library(${PROJECT_NAME}
+  src/compressor_command_controller.cpp
+  src/compressor_state_controller.cpp
+)
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+add_dependencies(${PROJECT_NAME} ${PROJECT_NAME}_generate_messages_cpp)
+
+# Install headers
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.h"
+)
+
+# Install libraries
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+# Install plugin file
+install(FILES ${PROJECT_NAME}_plugins.xml
+  DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+)

--- a/compressor_controller/compressor_controller_plugins.xml
+++ b/compressor_controller/compressor_controller_plugins.xml
@@ -1,0 +1,12 @@
+<library path="lib/libcompressor_controller">
+  <class name="compressor_controller/CompressorStateController" type="compressor_controller::CompressorStateController" base_class_type="controller_interface::ControllerBase">
+    <description>
+      Read info from the compressor
+    </description>
+  </class>
+  <class name="compressor_controller/CompressorCommandController" type="compressor_controller::CompressorCommandController" base_class_type="controller_interface::ControllerBase">
+    <description>
+      Command the compressor
+    </description>
+  </class>
+</library>

--- a/compressor_controller/include/compressor_controller/compressor_command_controller.h
+++ b/compressor_controller/include/compressor_controller/compressor_command_controller.h
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <compressor_controller/compressor_command_interface.h>
+#include <controller_interface/controller.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <realtime_tools/realtime_buffer.h>
+#include <ros/node_handle.h>
+#include <std_msgs/Bool.h>
+
+
+namespace compressor_controller {
+
+/**
+ * @brief Compressor controller.
+ *
+ * This class passes the binary (dual-state) command signal down to the compressor, controlling whether closed loop
+ * control is enabled or not.
+ *
+ * Subscribes to:
+ * - @bold command (std_msgs::Bool) : The closed loop control mode to apply.
+ */
+class CompressorCommandController
+    : public controller_interface::Controller<hardware_interface::CompressorCommandInterface> {
+public:
+  CompressorCommandController() = default;
+  ~CompressorCommandController() { sub_command_.shutdown(); }
+
+  bool init(hardware_interface::CompressorCommandInterface* hw, ros::NodeHandle& nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  hardware_interface::CompressorCommandHandle compressor_;
+  realtime_tools::RealtimeBuffer<bool>        command_buffer_;
+
+  ros::Subscriber sub_command_;
+  void            commandCallback(const std_msgs::BoolConstPtr& msg);
+};
+
+}  // namespace compressor_controller

--- a/compressor_controller/include/compressor_controller/compressor_command_interface.h
+++ b/compressor_controller/include/compressor_controller/compressor_command_interface.h
@@ -1,0 +1,67 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <compressor_controller/compressor_state_interface.h>
+#include <hardware_interface/internal/hardware_resource_manager.h>
+
+namespace hardware_interface {
+
+/** @brief A handle used to read and command a compressor. */
+class CompressorCommandHandle : public CompressorStateHandle {
+public:
+  CompressorCommandHandle() : CompressorStateHandle(), cmd_(nullptr) {}
+
+  /**
+   * @param state_handle This joint's state handle
+   * @param cmd A pointer to the storage for this joint's output command
+   */
+  CompressorCommandHandle(const CompressorStateHandle& state_handle, bool* cmd)
+      : CompressorStateHandle(state_handle), cmd_(cmd) {
+    if (!cmd_)
+      throw HardwareInterfaceException("Cannot create handle '" + getName() + "'. Command data pointer is null.");
+  }
+
+  void setCommand(bool command) {
+    assert(cmd_);
+    *cmd_ = command;
+  }
+
+  bool getCommand() const {
+    assert(cmd_);
+    return *cmd_;
+  }
+
+private:
+  bool* cmd_;
+};
+
+/** @brief Hardware interface to support commanding a compressor. */
+class CompressorCommandInterface : public HardwareResourceManager<CompressorCommandHandle, ClaimResources> {};
+
+}  // namespace hardware_interface

--- a/compressor_controller/include/compressor_controller/compressor_state_controller.h
+++ b/compressor_controller/include/compressor_controller/compressor_state_controller.h
@@ -1,0 +1,73 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+// ROS
+#include <controller_interface/controller.h>
+#include <realtime_tools/realtime_publisher.h>
+
+// Custom
+#include <compressor_controller/CompressorData.h>
+#include <compressor_controller/compressor_state_interface.h>
+
+namespace compressor_controller {
+
+/** @brief Controller that publishes the state of every compressor in a robot.
+ *
+ * This controller publishes the state of all resources registered to a `hardware_interface::CompressorStateHandle` to a
+ * topic of type `compressor_controller/CompressorData`. The following is a basic configuration of the controller.
+ *
+ * @code
+ * compressor_state_controller:
+ *   type: compressor_controller/CompressorStateController
+ *   publish_rate: 50
+ * @endcode
+ */
+class CompressorStateController
+    : public controller_interface::Controller<hardware_interface::CompressorStateInterface> {
+public:
+  CompressorStateController() : publish_rate_(15.0) {}
+
+  virtual bool init(hardware_interface::CompressorStateInterface* hw,
+                    ros::NodeHandle&                              root_nh,
+                    ros::NodeHandle&                              controller_nh) override;
+  virtual void starting(const ros::Time& time) override;
+  virtual void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  using RtPublisher         = realtime_tools::RealtimePublisher<compressor_controller::CompressorData>;
+  using RtPublisherPtr      = std::shared_ptr<RtPublisher>;
+  using RtPublisherConstPtr = std::shared_ptr<const RtPublisher>;
+
+  std::vector<hardware_interface::CompressorStateHandle> compressor_states_;
+  std::vector<RtPublisherPtr>                            realtime_pubs_;
+  std::vector<ros::Time>                                 last_publish_times_;
+  double                                                 publish_rate_;
+};
+
+}  // namespace compressor_controller

--- a/compressor_controller/include/compressor_controller/compressor_state_interface.h
+++ b/compressor_controller/include/compressor_controller/compressor_state_interface.h
@@ -1,0 +1,143 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <hardware_interface/internal/hardware_resource_manager.h>
+#include <string>
+
+namespace hardware_interface {
+
+/** @brief A handle used to read the state of a compressor. */
+class CompressorStateHandle {
+public:
+  struct CompressorState {
+    bool   enabled;          ///< If the compressor output is active
+    bool   pressure_switch;  ///< If the pressure switch is triggered (pressure is low)
+    double current;          ///< How much current the compressor is drawing
+    bool   closed_loop;      ///< If closed loop control of the compressor is enabled
+
+    bool fault_current_too_high;  ///< If the compressor output has been disabled due to high current draw
+    bool fault_shorted;           ///< If the compressor output has been disabled due to a short circuit
+    bool fault_not_connected;     ///< If the compressor output does not appear to be wired
+  };
+
+  CompressorStateHandle()
+      : name_(),
+        enabled_(nullptr),
+        pressure_switch_(nullptr),
+        current_(nullptr),
+        closed_loop_(nullptr),
+        fault_current_too_high_(nullptr),
+        fault_shorted_(nullptr),
+        fault_not_connected_(nullptr) {}
+
+  CompressorStateHandle(const std::string& name, const CompressorState* state)
+      : name_(name),
+        closed_loop_(&state->closed_loop),
+        enabled_(&state->enabled),
+        pressure_switch_(&state->pressure_switch),
+        current_(&state->current),
+        fault_current_too_high_(&state->fault_current_too_high),
+        fault_shorted_(&state->fault_shorted),
+        fault_not_connected_(&state->fault_not_connected) {}
+
+  CompressorStateHandle(const std::string& name,
+                        const bool*        closed_loop,
+                        const bool*        enabled,
+                        const bool*        pressure_switch,
+                        const double*      current,
+                        const bool*        fault_current_too_high,
+                        const bool*        fault_shorted,
+                        const bool*        fault_not_connected)
+      : name_(name),
+        closed_loop_(closed_loop),
+        enabled_(enabled),
+        pressure_switch_(pressure_switch),
+        current_(current),
+        fault_current_too_high_(fault_current_too_high),
+        fault_shorted_(fault_shorted),
+        fault_not_connected_(fault_not_connected) {
+
+    if (!closed_loop_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Closed loop mode pointer is null.");
+    if (!enabled_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Enabled pointer is null.");
+    if (!pressure_switch_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Pressure switch pointer is null.");
+    if (!current_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Current pointer is null.");
+    if (!fault_current_too_high_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Current too high fault pointer is null.");
+    if (!fault_shorted_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Shorted fault pointer is null.");
+    if (!fault_not_connected_)
+      throw HardwareInterfaceException("Cannot create compressor state handle '" + name
+                                       + "'. Not connected fault pointer is null.");
+  }
+
+  // clang-format off
+  std::string getName() const                     {return name_;}
+
+  bool   getClosedLoop() const                    {assert(closed_loop_);            return *closed_loop_;}
+  bool   getEnabled() const                       {assert(enabled_);                return *enabled_;}
+  bool   getPressureSwitch() const                {assert(pressure_switch_);        return *pressure_switch_;}
+  double getCurrent() const                       {assert(current_);                return *current_;}
+  bool   getFaultCurrentTooHigh() const           {assert(fault_current_too_high_); return *fault_current_too_high_;}
+  bool   getFaultShorted() const                  {assert(fault_shorted_);          return *fault_shorted_;}
+  bool   getFaultNotConnected() const             {assert(fault_not_connected_);    return *fault_not_connected_;}
+
+  const bool*   getClosedLoopPtr() const          {return closed_loop_;}
+  const bool*   getEnabledPtr() const             {return enabled_;}
+  const bool*   getPressureSwitchPtr() const      {return pressure_switch_;}
+  const double* getCurrentPtr() const             {return current_;}
+  const bool*   getFaultCurrentTooHighPtr() const {return fault_current_too_high_;}
+  const bool*   getFaultShortedPtr() const        {return fault_shorted_;}
+  const bool*   getFaultNotConnectedPtr() const   {return fault_not_connected_;}
+  // clang-format on
+
+private:
+  std::string   name_;
+  const bool*   closed_loop_;
+  const bool*   enabled_;
+  const bool*   pressure_switch_;
+  const double* current_;
+  const bool*   fault_current_too_high_;
+  const bool*   fault_shorted_;
+  const bool*   fault_not_connected_;
+};
+
+/** @brief Hardware interface to support reading the state of a compressor. */
+class CompressorStateInterface : public HardwareResourceManager<CompressorStateHandle> {};
+
+}  // namespace hardware_interface

--- a/compressor_controller/msg/CompressorData.msg
+++ b/compressor_controller/msg/CompressorData.msg
@@ -1,0 +1,10 @@
+Header header
+
+bool    closed_loop     # If closed loop control of the compressor is enabled
+bool    enabled         # If the compressor output is active
+bool    pressure_switch # If the pressure switch is triggered (pressure is low)
+float64 current         # How much current the compressor is drawing
+
+bool fault_current_too_high # If the compressor output has been disabled due to high current draw
+bool fault_shorted          # If the compressor output has been disabled due to a short circuit
+bool fault_not_connected    # If the compressor output does not appear to be wired

--- a/compressor_controller/package.xml
+++ b/compressor_controller/package.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>compressor_controller</name>
+  <version>0.0.0</version>
+  <description>Controller to control and publish state of compressors</description>
+
+  <maintainer email="mtreynolds@uwaterloo.ca">Matt Reynolds</maintainer>
+
+  <license>BSD-3</license>
+
+  <url type="website">https://uwreact.ca</url>
+  <!-- <url type="website">http://wiki.ros.org/frc_control</url> -->
+  <url type="bugtracker">https://github.com/uwreact/frc_control/issues</url>
+  <url type="repository">https://github.com/uwreact/frc_control</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+  <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>realtime_tools</depend>
+  <depend>roscpp</depend>
+  <depend>std_msgs</depend>
+
+  <build_depend>message_generation</build_depend>
+  <exec_depend>message_runtime</exec_depend>
+
+  <export>
+    <controller_interface plugin="${prefix}/compressor_controller_plugins.xml"/>
+  </export>
+</package>

--- a/compressor_controller/src/compressor_command_controller.cpp
+++ b/compressor_controller/src/compressor_command_controller.cpp
@@ -1,0 +1,59 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <compressor_controller/compressor_command_controller.h>
+#include <pluginlib/class_list_macros.hpp>
+
+namespace compressor_controller {
+
+bool CompressorCommandController::init(hardware_interface::CompressorCommandInterface* hw, ros::NodeHandle& nh) {
+  std::string joint_name;
+  if (!nh.getParam("joint", joint_name)) {
+    ROS_ERROR("No joint given (namespace: %s)", nh.getNamespace().c_str());
+    return false;
+  }
+  compressor_ = hw->getHandle(joint_name);
+
+  sub_command_ = nh.subscribe<std_msgs::Bool>("command", 1, &CompressorCommandController::commandCallback, this);
+  return true;
+}
+
+void CompressorCommandController::starting(const ros::Time& /*time*/) {
+  command_buffer_.writeFromNonRT(true);
+}
+
+void CompressorCommandController::update(const ros::Time& /*time*/, const ros::Duration& /*period*/) {
+  compressor_.setCommand(*command_buffer_.readFromRT());
+}
+
+void CompressorCommandController::commandCallback(const std_msgs::BoolConstPtr& msg) {
+  command_buffer_.writeFromNonRT((bool) msg->data);
+}
+
+}  // namespace compressor_controller
+
+PLUGINLIB_EXPORT_CLASS(compressor_controller::CompressorCommandController, controller_interface::ControllerBase)

--- a/compressor_controller/src/compressor_state_controller.cpp
+++ b/compressor_controller/src/compressor_state_controller.cpp
@@ -73,8 +73,8 @@ void CompressorStateController::update(const ros::Time& time, const ros::Duratio
         last_publish_times_[i] = last_publish_times_[i] + ros::Duration(1.0 / publish_rate_);
 
         // Populate message
-        // Note: clang_tidy doesn't like implicit conversion from bool to ROS msg bools, since msg bools are implemented
-        // as uint8_t (readability-implicit-bool-conversion). We therefore disable linting on these lines.
+        // Note: clang-tidy doesn't like implicit conversion from bool to ROS msg bools, since ROS msg bools are
+        // implemented as uint8_t. Disable linting to prevent readability-implicit-bool-conversion warning
         realtime_pubs_[i]->msg_.header.stamp           = time;
         realtime_pubs_[i]->msg_.closed_loop            = compressor_states_[i].getClosedLoop();      // NOLINT
         realtime_pubs_[i]->msg_.enabled                = compressor_states_[i].getEnabled();         // NOLINT

--- a/compressor_controller/src/compressor_state_controller.cpp
+++ b/compressor_controller/src/compressor_state_controller.cpp
@@ -1,0 +1,96 @@
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2019, UW REACT
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are met:
+//   * Redistributions of source code must retain the above copyright notice,
+//     this list of conditions and the following disclaimer.
+//   * Redistributions in binary form must reproduce the above copyright
+//     notice, this list of conditions and the following disclaimer in the
+//     documentation and/or other materials provided with the distribution.
+//   * Neither the name of UW REACT, nor the names of its
+//     contributors may be used to endorse or promote products derived from
+//     this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+// LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+// POSSIBILITY OF SUCH DAMAGE.
+//////////////////////////////////////////////////////////////////////////////
+
+#include <compressor_controller/compressor_state_controller.h>
+
+#include <algorithm>
+#include <pluginlib/class_list_macros.h>
+
+namespace compressor_controller {
+
+bool CompressorStateController::init(hardware_interface::CompressorStateInterface* hw,
+                                     ros::NodeHandle&                              root_nh,
+                                     ros::NodeHandle&                              controller_nh) {
+
+  // Get all compressor names from the hardware interface
+  const std::vector<std::string>& compressor_names = hw->getNames();
+
+  // Get publishing period
+  if (!controller_nh.getParam("publish_rate", publish_rate_)) {
+    ROS_ERROR("CompressorStateController parameter 'publish_rate' not set");
+    return false;
+  }
+
+  // Setup publishers
+  for (const auto& compressor_name : compressor_names) {
+    ROS_DEBUG("Got compressor %s", compressor_name.c_str());
+    compressor_states_.push_back(hw->getHandle(compressor_name));
+
+    realtime_pubs_.push_back(std::make_shared<RtPublisher>(root_nh, compressor_name, 4));
+  }
+
+  // Last published times
+  last_publish_times_.resize(compressor_names.size());
+  return true;
+}
+
+void CompressorStateController::starting(const ros::Time& time) {
+  std::fill(last_publish_times_.begin(), last_publish_times_.end(), time);
+}
+
+void CompressorStateController::update(const ros::Time& time, const ros::Duration& /*period*/) {
+  for (unsigned i = 0; i < realtime_pubs_.size(); i++) {
+
+    // Limit rate of publishing
+    if ((publish_rate_ > 0.0) && (last_publish_times_[i] + ros::Duration(1.0 / publish_rate_) < time)) {
+
+      // Try to publish
+      if (realtime_pubs_[i]->trylock()) {
+        last_publish_times_[i] = last_publish_times_[i] + ros::Duration(1.0 / publish_rate_);
+
+        // Populate message
+        // Note: clang_tidy doesn't like implicit conversion from bool to ROS msg bools, since msg bools are implemented
+        // as uint8_t (readability-implicit-bool-conversion). We therefore disable linting on these lines.
+        realtime_pubs_[i]->msg_.header.stamp           = time;
+        realtime_pubs_[i]->msg_.closed_loop            = compressor_states_[i].getClosedLoop();      // NOLINT
+        realtime_pubs_[i]->msg_.enabled                = compressor_states_[i].getEnabled();         // NOLINT
+        realtime_pubs_[i]->msg_.pressure_switch        = compressor_states_[i].getPressureSwitch();  // NOLINT
+        realtime_pubs_[i]->msg_.current                = compressor_states_[i].getCurrent();
+        realtime_pubs_[i]->msg_.fault_current_too_high = compressor_states_[i].getFaultCurrentTooHigh();  // NOLINT
+        realtime_pubs_[i]->msg_.fault_shorted          = compressor_states_[i].getFaultShorted();         // NOLINT
+        realtime_pubs_[i]->msg_.fault_not_connected    = compressor_states_[i].getFaultNotConnected();    // NOLINT
+
+        // Publish data
+        realtime_pubs_[i]->unlockAndPublish();
+      }
+    }
+  }
+}
+
+}  // namespace compressor_controller
+
+PLUGINLIB_EXPORT_CLASS(compressor_controller::CompressorStateController, controller_interface::ControllerBase)

--- a/frc_control/package.xml
+++ b/frc_control/package.xml
@@ -15,14 +15,15 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <exec_depend>analog_controller</exec_depend>
+  <exec_depend>binary_controller</exec_depend>
+  <exec_depend>compressor_controller</exec_depend>
+  <exec_depend>driver_station</exec_depend>
   <exec_depend>frc_msgs</exec_depend>
   <exec_depend>frc_robot_hw</exec_depend>
   <exec_depend>frc_robot_sim</exec_depend>
-  <exec_depend>analog_controller</exec_depend>
-  <exec_depend>binary_controller</exec_depend>
-  <exec_depend>ternary_controller</exec_depend>
   <exec_depend>pdp_state_controller</exec_depend>
-  <exec_depend>driver_station</exec_depend>
+  <exec_depend>ternary_controller</exec_depend>
 
   <export>
     <metapackage/>

--- a/frc_robot_hw/CMakeLists.txt
+++ b/frc_robot_hw/CMakeLists.txt
@@ -14,9 +14,10 @@ find_package(catkin REQUIRED COMPONENTS
 
   analog_controller
   binary_controller
+  compressor_controller
   frc_msgs
-  ternary_controller
   pdp_state_controller
+  ternary_controller
 )
 
 # Declare a catkin package
@@ -35,9 +36,10 @@ catkin_package(
 
     analog_controller
     binary_controller
+    compressor_controller
     frc_msgs
-    ternary_controller
     pdp_state_controller
+    ternary_controller
 )
 
 # Specify additional locations of header files

--- a/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
+++ b/frc_robot_hw/include/frc_robot_hw/frc_robot_hw.h
@@ -54,6 +54,7 @@
 // Custom
 #include <analog_controller/analog_command_interface.h>
 #include <binary_controller/binary_command_interface.h>
+#include <compressor_controller/compressor_command_interface.h>
 #include <pdp_state_controller/pdp_state_interface.h>
 #include <ternary_controller/ternary_command_interface.h>
 
@@ -70,8 +71,9 @@ protected:
 public:
   FRCRobotHW() : FRCRobotHW("frc_robot_hw") {}
 
-  using TernaryState = hardware_interface::TernaryStateHandle::TernaryState;
-  using PDPState     = hardware_interface::PDPStateHandle::PDPState;
+  using TernaryState    = hardware_interface::TernaryStateHandle::TernaryState;
+  using CompressorState = hardware_interface::CompressorStateHandle::CompressorState;
+  using PDPState        = hardware_interface::PDPStateHandle::PDPState;
 
   /// Joint feedback data
   struct JointState {
@@ -162,12 +164,13 @@ protected:
   const std::string name_;
 
   // Hardware state interfaces
-  hardware_interface::JointStateInterface   joint_state_interface_;
-  hardware_interface::PDPStateInterface     pdp_state_interface_;
-  hardware_interface::AnalogStateInterface  analog_state_interface_;
-  hardware_interface::BinaryStateInterface  binary_state_interface_;
-  hardware_interface::TernaryStateInterface ternary_state_interface_;
-  hardware_interface::ImuSensorInterface    imu_sensor_interface_;
+  hardware_interface::JointStateInterface      joint_state_interface_;
+  hardware_interface::ImuSensorInterface       imu_sensor_interface_;
+  hardware_interface::AnalogStateInterface     analog_state_interface_;
+  hardware_interface::BinaryStateInterface     binary_state_interface_;
+  hardware_interface::CompressorStateInterface compressor_state_interface_;
+  hardware_interface::PDPStateInterface        pdp_state_interface_;
+  hardware_interface::TernaryStateInterface    ternary_state_interface_;
 
   // Transmission interfaces
   // Convert actuator state to joint state
@@ -176,13 +179,14 @@ protected:
   // transmission_interface::JointToActuatorStateInterface jnt_to_act_state_interface_;
 
   // Hardware command iterfaces
-  hardware_interface::PositionJointInterface  joint_position_command_interface_;  // Position
-  hardware_interface::VelocityJointInterface  joint_velocity_command_interface_;  // Veloicty
-  hardware_interface::EffortJointInterface    joint_effort_command_interface_;    // Effort
-  hardware_interface::VoltageJointInterface   joint_voltage_command_interface_;   // Voltage (-12ish to 12ish)
-  hardware_interface::AnalogCommandInterface  analog_command_interface_;
-  hardware_interface::BinaryCommandInterface  binary_command_interface_;
-  hardware_interface::TernaryCommandInterface ternary_command_interface_;
+  hardware_interface::PositionJointInterface     joint_position_command_interface_;  // Position
+  hardware_interface::VelocityJointInterface     joint_velocity_command_interface_;  // Veloicty
+  hardware_interface::EffortJointInterface       joint_effort_command_interface_;    // Effort
+  hardware_interface::VoltageJointInterface      joint_voltage_command_interface_;   // Voltage (-12ish to 12ish)
+  hardware_interface::AnalogCommandInterface     analog_command_interface_;
+  hardware_interface::BinaryCommandInterface     binary_command_interface_;
+  hardware_interface::CompressorCommandInterface compressor_command_interface_;
+  hardware_interface::TernaryCommandInterface    ternary_command_interface_;
 
   // Sensors and actuator templates
   // TODO: Change servo_templates_ to struct containing scale?
@@ -219,19 +223,20 @@ protected:
 
   // States
   // std::map<std::string, JointState> actuator_states_;///< Transmission stuff
-  std::map<std::string, JointState>   joint_states_;    ///< State of SpeedControllers, (Servos???)
-  std::map<std::string, PDPState>     pdp_states_;      ///< State of PowerDistributionPanels
-  std::map<std::string, RateState>    rate_states_;     ///< State of AnalogInput/Outputs, Encoders, etc
-  std::map<std::string, bool>         binary_states_;   ///< State of DigitalInputs/Outputs, Solenoids, etc
-  std::map<std::string, TernaryState> ternary_states_;  ///< State of Relays, DoubleSolenoids, etc
-  std::map<std::string, ImuData>      imu_states_;      ///< State of IMUs such as PigeonIMU, NavX
+  std::map<std::string, JointState>      joint_states_;       ///< State of SpeedControllers, (Servos???)
+  std::map<std::string, ImuData>         imu_states_;         ///< State of IMUs such as PigeonIMU, NavX
+  std::map<std::string, bool>            binary_states_;      ///< State of DigitalInputs/Outputs, Solenoids, etc
+  std::map<std::string, CompressorState> compressor_states_;  ///< State of Compressors
+  std::map<std::string, PDPState>        pdp_states_;         ///< State of PowerDistributionPanels
+  std::map<std::string, RateState>       rate_states_;        ///< State of AnalogInput/Outputs, Encoders, etc
+  std::map<std::string, TernaryState>    ternary_states_;     ///< State of Relays, DoubleSolenoids, etc
 
   // Commands
   // TODO: Servos as Joint or Analog commands?
   // std::map<std::string, double> actuator_commands_;    ///< Transmission stuff
   std::map<std::string, JointCmd>     joint_commands_;    ///< Commands for SpeedControllers, Servos
   std::map<std::string, double>       analog_commands_;   ///< Commands for AnalogOutputs
-  std::map<std::string, bool>         binary_commands_;   ///< Commands for DigitalOutputs, Solenoids
+  std::map<std::string, bool>         binary_commands_;   ///< Commands for DigitalOutputs, Solenoids, Compressors
   std::map<std::string, TernaryState> ternary_commands_;  ///< Commands for Relays, DoubleSolenoids
 
 private:

--- a/frc_robot_hw/package.xml
+++ b/frc_robot_hw/package.xml
@@ -24,10 +24,11 @@
   <depend>tinyxml2</depend>
   <depend>urdf</depend>
 
-  <depend>frc_msgs</depend>
   <depend>analog_controller</depend>
   <depend>binary_controller</depend>
-  <depend>ternary_controller</depend>
+  <depend>compressor_controller</depend>
+  <depend>frc_msgs</depend>
   <depend>pdp_state_controller</depend>
+  <depend>ternary_controller</depend>
 
 </package>

--- a/frc_robot_hw/src/frc_robot_hw.cpp
+++ b/frc_robot_hw/src/frc_robot_hw.cpp
@@ -637,10 +637,10 @@ bool FRCRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
   // Register a command handle for each compressor
   for (const auto& pair : compressor_templates_) {
     ROS_DEBUG_STREAM_NAMED(name_, "Registering interface for compressor " << pair.first);
-    hardware_interface::BinaryStateHandle state_handle(pair.first, &binary_states_[pair.first]);
-    binary_state_interface_.registerHandle(state_handle);
-    binary_command_interface_.registerHandle(
-        hardware_interface::BinaryCommandHandle(state_handle, &binary_commands_[pair.first]));
+    hardware_interface::CompressorStateHandle state_handle(pair.first, &compressor_states_[pair.first]);
+    compressor_state_interface_.registerHandle(state_handle);
+    compressor_command_interface_.registerHandle(
+        hardware_interface::CompressorCommandHandle(state_handle, &binary_commands_[pair.first]));
   }
 
   // Register a state handle for each digital input
@@ -777,6 +777,8 @@ bool FRCRobotHW::init(ros::NodeHandle& root_nh, ros::NodeHandle& robot_hw_nh) {
   registerInterface(&joint_velocity_command_interface_);
   registerInterface(&joint_effort_command_interface_);
   registerInterface(&joint_voltage_command_interface_);
+  registerInterface(&compressor_state_interface_);
+  registerInterface(&compressor_command_interface_);
 
   return true;
 }

--- a/frc_robot_hw/src/frc_robot_hw_real.cpp
+++ b/frc_robot_hw/src/frc_robot_hw_real.cpp
@@ -708,9 +708,14 @@ void FRCRobotHWReal::read(const ros::Time& time, const ros::Duration& period) {
   // =*=*=*=*=*=*=*= Misc =*=*=*=*=*=*=*=
 
   // Read current Compressor states
-  // TODO: Implement current, pressure switch feedback
   for (const auto& pair : compressors_) {
-    binary_states_[pair.first] = pair.second->GetClosedLoopControl();
+    compressor_states_[pair.first].closed_loop            = pair.second->GetClosedLoopControl();
+    compressor_states_[pair.first].enabled                = pair.second->Enabled();
+    compressor_states_[pair.first].pressure_switch        = pair.second->GetPressureSwitchValue();
+    compressor_states_[pair.first].current                = pair.second->GetCompressorCurrent();
+    compressor_states_[pair.first].fault_current_too_high = pair.second->GetCompressorCurrentTooHighFault();
+    compressor_states_[pair.first].fault_shorted          = pair.second->GetCompressorShortedFault();
+    compressor_states_[pair.first].fault_not_connected    = pair.second->GetCompressorNotConnectedFault();
   }
 
   // Read current PDP current draw states


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

While we look over every pull request, we maintain a focus on this project's current roadmap. If your pull request does not fit within this project's current roadmap or fix an open issue, it may be closed. Please reference any relevant issues, label accordingly, and detail your changes as much as possible.
-->

# Pull Request

<!-- Provide more details below this comment. -->
Closes #6.

Adds custom controllers for publishing the state of compressors (whether the output is enabled, the pressure is low, the current draw, and various faults) and for commanding the compressor (whether to enable closed-loop control or not).

In the future, these two controllers could perhaps be merged into one, not sure if they really need to be split the way they are right now. It also might be worth pulling the compressor and pdp controllers into a common `frc_controllers` package. For both of these, I'm not sure if I actually want to make these changes or not, so I'll leave them as potential future changes.

## Contribution Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [x] I have read the [contributing](https://github.com/uwreact/frc_control/blob/melodic-devel/CONTRIBUTING.md) guide.
- [x] I have referenced relevant issues.
- [x] I have labeled accordingly.
- [x] I have detailed my changes as much as possible.

## Change Checklist

<!-- Put an 'x' in the boxes that apply. -->

- [ ] I have added tests.
- [x] I have added necessary documentation.
- [x] I have auto formatted using clang-format or yapf.
